### PR TITLE
CAPS 66: 백엔드 orm 관련 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,10 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+
+	// Swagger
+	implementation 'io.springfox:springfox-boot-starter:3.0.0'
+	implementation 'io.springfox:springfox-swagger-ui:3.0.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hidiscuss/backend/config/QuerydslConfig.java
+++ b/src/main/java/com/hidiscuss/backend/config/QuerydslConfig.java
@@ -3,10 +3,8 @@ package com.hidiscuss.backend.config;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 
 @Configuration
 public class QuerydslConfig {

--- a/src/main/java/com/hidiscuss/backend/config/SwaggerConfig.java
+++ b/src/main/java/com/hidiscuss/backend/config/SwaggerConfig.java
@@ -1,0 +1,49 @@
+package com.hidiscuss.backend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Configuration
+@EnableWebMvc
+public class SwaggerConfig {
+
+    private ApiInfo swaggerInfo() {
+        return new ApiInfoBuilder().title("Hidiscuss!")
+                .description("HiDiscuss API Docs").build();
+    }
+
+    @Bean
+    public Docket swaggerApi() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .consumes(getConsumeContentTypes())
+                .produces(getProduceContentTypes())
+                .apiInfo(swaggerInfo()).select()
+                .apis(RequestHandlerSelectors.basePackage("com.hidiscuss.backend.controller"))
+                .paths(PathSelectors.any())
+                .build()
+                .useDefaultResponseMessages(false);
+    }
+
+    private Set<String> getConsumeContentTypes() {
+        Set<String> consumes = new HashSet<>();
+        consumes.add("application/json;charset=UTF-8");
+        consumes.add("application/x-www-form-urlencoded");
+        return consumes;
+    }
+
+    private Set<String> getProduceContentTypes() {
+        Set<String> produces = new HashSet<>();
+        produces.add("application/json;charset=UTF-8");
+        return produces;
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/controller/UserController.java
+++ b/src/main/java/com/hidiscuss/backend/controller/UserController.java
@@ -2,6 +2,9 @@ package com.hidiscuss.backend.controller;
 
 import com.hidiscuss.backend.entity.User;
 import com.hidiscuss.backend.service.UserService;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,6 +23,11 @@ public class UserController {
         this.userService = userService;
     }
 
+    @ApiOperation(value="테스트 사용자 호출", notes="이 api는 테스트 api입니다. 여기에 api 동작 설명을 작성해주세요.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "API 정상 작동"),
+            @ApiResponse(code = 500, message = "서버 에러")
+    })
     @GetMapping("/userlist")
     public ResponseEntity<List<User>> getUserList() {
         return new ResponseEntity<>(userService.getUserList(), HttpStatus.OK);

--- a/src/main/java/com/hidiscuss/backend/entity/BaseEntity.java
+++ b/src/main/java/com/hidiscuss/backend/entity/BaseEntity.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 @MappedSuperclass
 @EntityListeners(value = {AuditingEntityListener.class})
@@ -17,17 +17,9 @@ abstract class BaseEntity {
 
     @CreatedDate
     @Column(name = "created_at", updatable = false, nullable = false)
-    private Timestamp createdAt;
+    private LocalDateTime createdAt;
 
     @LastModifiedDate
     @Column(name = "last_modified_at", nullable = false)
-    private Timestamp lastModifiedAt;
-
-    @Column(name = "created_user_id")
-    private Long createdUserId;
-
-    @Column(name = "modified_user_id")
-    private Long modifiedUserId;
-
-
+    private LocalDateTime lastModifiedAt;
 }

--- a/src/main/java/com/hidiscuss/backend/entity/BaseEntity.java
+++ b/src/main/java/com/hidiscuss/backend/entity/BaseEntity.java
@@ -1,0 +1,33 @@
+package com.hidiscuss.backend.entity;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.sql.Timestamp;
+
+@MappedSuperclass
+@EntityListeners(value = {AuditingEntityListener.class})
+@Getter
+abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private Timestamp createdAt;
+
+    @LastModifiedDate
+    @Column(name = "last_modified_at")
+    private Timestamp lastModifiedAt;
+
+    @Column(name = "created_user_id")
+    private Long createdUserId;
+
+    @Column(name = "modified_user_id")
+    private Long modifiedUserId;
+
+
+}

--- a/src/main/java/com/hidiscuss/backend/entity/BaseEntity.java
+++ b/src/main/java/com/hidiscuss/backend/entity/BaseEntity.java
@@ -20,7 +20,7 @@ abstract class BaseEntity {
     private Timestamp createdAt;
 
     @LastModifiedDate
-    @Column(name = "last_modified_at")
+    @Column(name = "last_modified_at", nullable = false)
     private Timestamp lastModifiedAt;
 
     @Column(name = "created_user_id")

--- a/src/main/java/com/hidiscuss/backend/entity/Discussion.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Discussion.java
@@ -31,13 +31,13 @@ public class Discussion extends BaseEntity {
     private Boolean liveReviewRequired;
 
     @Column(name = "live_review_available_times")
-    private Boolean liveReviewAvailableTimes;
+    private String liveReviewAvailableTimes;
 
     @Column(name = "priority", nullable = false)
     private Long priority;
 
     @Builder
-    public Discussion(Long id, State state, User user, String question, Boolean liveReviewRequired, Boolean liveReviewAvailableTimes, Long priority) {
+    public Discussion(Long id, State state, User user, String question, Boolean liveReviewRequired, String liveReviewAvailableTimes, Long priority) {
         this.id = id;
         this.state = state;
         this.user = user;

--- a/src/main/java/com/hidiscuss/backend/entity/Discussion.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Discussion.java
@@ -1,10 +1,14 @@
 package com.hidiscuss.backend.entity;
 
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import javax.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
+@Getter
+@NoArgsConstructor
 @Table(name = "Discussion")
 public class Discussion extends BaseEntity {
     @Id
@@ -31,4 +35,15 @@ public class Discussion extends BaseEntity {
 
     @Column(name = "priority", nullable = false)
     private Long priority;
+
+    @Builder
+    public Discussion(Long id, State state, User user, String question, Boolean liveReviewRequired, Boolean liveReviewAvailableTimes, Long priority) {
+        this.id = id;
+        this.state = state;
+        this.user = user;
+        this.question = question;
+        this.liveReviewRequired = liveReviewRequired;
+        this.liveReviewAvailableTimes = liveReviewAvailableTimes;
+        this.priority = priority;
+    }
 }

--- a/src/main/java/com/hidiscuss/backend/entity/Discussion.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Discussion.java
@@ -1,0 +1,31 @@
+package com.hidiscuss.backend.entity;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name="Discussion")
+public class Discussion {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name="state")
+    private State state;
+
+    @ManyToOne
+    @JoinColumn(name="user_id")
+    private User user;
+
+    @Column(name="question")
+    private String question;
+
+    @Column(name="live_review_required")
+    private Boolean liveReviewRequired;
+
+    @Column(name="live_review_available_times")
+    private Boolean liveReviewAvailableTimes;
+
+    @Column(name="priority")
+    private Long priority;
+}

--- a/src/main/java/com/hidiscuss/backend/entity/Discussion.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Discussion.java
@@ -17,8 +17,8 @@ public class Discussion extends BaseEntity {
     private Long id;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "state", nullable = false)
-    private State state;
+    @Column(columnDefinition = "enum('NOT_REVIEWED', 'REVIEWING', 'COMPLETED') default 'NOT_REVIEWED'", name = "state", nullable = false)
+    private DiscussionState state;
 
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
@@ -27,17 +27,17 @@ public class Discussion extends BaseEntity {
     @Column(name = "question", nullable = false)
     private String question;
 
-    @Column(name = "live_review_required", nullable = false)
+    @Column(columnDefinition = "boolean default false", name = "live_review_required", nullable = false)
     private Boolean liveReviewRequired;
 
     @Column(name = "live_review_available_times")
     private String liveReviewAvailableTimes;
 
-    @Column(name = "priority", nullable = false)
+    @Column(columnDefinition = "bigint default 0", name = "priority", nullable = false)
     private Long priority;
 
     @Builder
-    public Discussion(Long id, State state, User user, String question, Boolean liveReviewRequired, String liveReviewAvailableTimes, Long priority) {
+    public Discussion(Long id, DiscussionState state, User user, String question, Boolean liveReviewRequired, String liveReviewAvailableTimes, Long priority) {
         this.id = id;
         this.state = state;
         this.user = user;

--- a/src/main/java/com/hidiscuss/backend/entity/Discussion.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Discussion.java
@@ -1,31 +1,36 @@
 package com.hidiscuss.backend.entity;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
-@Table(name="Discussion")
-public class Discussion {
+@Table(name = "Discussion")
+public class Discussion extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Enumerated(EnumType.STRING)
-    @Column(name="state")
+    @Column(name = "state")
     private State state;
 
     @ManyToOne
-    @JoinColumn(name="user_id")
+    @JoinColumn(name = "user_id")
     private User user;
 
-    @Column(name="question")
+    @Column(name = "question")
     private String question;
 
-    @Column(name="live_review_required")
+    @Column(name = "live_review_required")
     private Boolean liveReviewRequired;
 
-    @Column(name="live_review_available_times")
+    @Column(name = "live_review_available_times")
     private Boolean liveReviewAvailableTimes;
 
-    @Column(name="priority")
+    @Column(name = "priority")
     private Long priority;
+
+    @OneToMany(mappedBy = "discussion")
+    private List<DiscussionCode> discussionCodes = new ArrayList<>();
 }

--- a/src/main/java/com/hidiscuss/backend/entity/Discussion.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Discussion.java
@@ -9,25 +9,26 @@ import java.util.List;
 public class Discussion extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
     private Long id;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "state")
+    @Column(name = "state", nullable = false)
     private State state;
 
     @ManyToOne
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(name = "question")
+    @Column(name = "question", nullable = false)
     private String question;
 
-    @Column(name = "live_review_required")
+    @Column(name = "live_review_required", nullable = false)
     private Boolean liveReviewRequired;
 
     @Column(name = "live_review_available_times")
     private Boolean liveReviewAvailableTimes;
 
-    @Column(name = "priority")
+    @Column(name = "priority", nullable = false)
     private Long priority;
 }

--- a/src/main/java/com/hidiscuss/backend/entity/Discussion.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Discussion.java
@@ -30,7 +30,4 @@ public class Discussion extends BaseEntity {
 
     @Column(name = "priority")
     private Long priority;
-
-    @OneToMany(mappedBy = "discussion")
-    private List<DiscussionCode> discussionCodes = new ArrayList<>();
 }

--- a/src/main/java/com/hidiscuss/backend/entity/DiscussionCode.java
+++ b/src/main/java/com/hidiscuss/backend/entity/DiscussionCode.java
@@ -39,7 +39,7 @@ public class DiscussionCode extends BaseEntity {
     @Column(name = "changes", nullable = false)
     private Long changes;
 
-    @Column(name = "content", nullable = false)
+    @Column(columnDefinition = "MEDIUMTEXT", name = "content", nullable = false)
     private String content;
 
     @Builder

--- a/src/main/java/com/hidiscuss/backend/entity/DiscussionCode.java
+++ b/src/main/java/com/hidiscuss/backend/entity/DiscussionCode.java
@@ -7,32 +7,33 @@ import javax.persistence.*;
 public class DiscussionCode extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
     private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "discussion_id")
+    @JoinColumn(name = "discussion_id", nullable = false)
     private Discussion discussion;
 
-    @Column(name = "sha")
+    @Column(name = "sha", nullable = false)
     private String sha;
 
-    @Column(name = "filename")
+    @Column(name = "filename", nullable = false)
     private String filename;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status")
+    @Column(name = "status", nullable = false)
     private Status status;
 
-    @Column(name = "additions")
+    @Column(name = "additions", nullable = false)
     private Long additions;
 
-    @Column(name = "deletions")
+    @Column(name = "deletions", nullable = false)
     private Long deletions;
 
-    @Column(name = "changes")
+    @Column(name = "changes", nullable = false)
     private Long changes;
 
-    @Column(name = "content")
+    @Column(name = "content", nullable = false)
     private String content;
 
 }

--- a/src/main/java/com/hidiscuss/backend/entity/DiscussionCode.java
+++ b/src/main/java/com/hidiscuss/backend/entity/DiscussionCode.java
@@ -1,8 +1,14 @@
 package com.hidiscuss.backend.entity;
 
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import javax.persistence.*;
 
 @Entity
+@Getter
+@NoArgsConstructor
 @Table(name = "DiscussionCode")
 public class DiscussionCode extends BaseEntity {
     @Id
@@ -36,4 +42,16 @@ public class DiscussionCode extends BaseEntity {
     @Column(name = "content", nullable = false)
     private String content;
 
+    @Builder
+    public DiscussionCode(Long id, Discussion discussion, String sha, String filename, Status status, Long additions, Long deletions, Long changes, String content) {
+        this.id = id;
+        this.discussion = discussion;
+        this.sha = sha;
+        this.filename = filename;
+        this.status = status;
+        this.additions = additions;
+        this.deletions = deletions;
+        this.changes = changes;
+        this.content = content;
+    }
 }

--- a/src/main/java/com/hidiscuss/backend/entity/DiscussionCode.java
+++ b/src/main/java/com/hidiscuss/backend/entity/DiscussionCode.java
@@ -1,0 +1,38 @@
+package com.hidiscuss.backend.entity;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "DiscussionCode")
+public class DiscussionCode extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "discussion_id")
+    private Discussion discussion;
+
+    @Column(name = "sha")
+    private String sha;
+
+    @Column(name = "filename")
+    private String filename;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status")
+    private Status status;
+
+    @Column(name = "additions")
+    private Long additions;
+
+    @Column(name = "deletions")
+    private Long deletions;
+
+    @Column(name = "changes")
+    private Long changes;
+
+    @Column(name = "content")
+    private String content;
+
+}

--- a/src/main/java/com/hidiscuss/backend/entity/DiscussionState.java
+++ b/src/main/java/com/hidiscuss/backend/entity/DiscussionState.java
@@ -1,11 +1,11 @@
 package com.hidiscuss.backend.entity;
 
-public enum State {
+public enum DiscussionState {
     NOT_REVIEWED(0), REVIEWING(1), COMPLETED(2);
 
     private int id;
 
-    State(int id) {
+    DiscussionState(int id) {
         this.id = id;
     }
 

--- a/src/main/java/com/hidiscuss/backend/entity/DiscussionTag.java
+++ b/src/main/java/com/hidiscuss/backend/entity/DiscussionTag.java
@@ -1,0 +1,20 @@
+package com.hidiscuss.backend.entity;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "DiscussionTag")
+public class DiscussionTag extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "discussion_id", nullable = false)
+    private Discussion discussion;
+
+    @ManyToOne
+    @JoinColumn(name = "tag_id", nullable = false)
+    private Tag tag;
+}

--- a/src/main/java/com/hidiscuss/backend/entity/DiscussionTag.java
+++ b/src/main/java/com/hidiscuss/backend/entity/DiscussionTag.java
@@ -9,7 +9,10 @@ import javax.persistence.*;
 @Entity
 @Getter
 @NoArgsConstructor
-@Table(name = "DiscussionTag")
+@Table(name = "DiscussionTag",
+        uniqueConstraints = @UniqueConstraint(
+                columnNames = {"discussion_id", "tag_id"})
+)
 public class DiscussionTag extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/hidiscuss/backend/entity/DiscussionTag.java
+++ b/src/main/java/com/hidiscuss/backend/entity/DiscussionTag.java
@@ -1,8 +1,14 @@
 package com.hidiscuss.backend.entity;
 
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import javax.persistence.*;
 
 @Entity
+@Getter
+@NoArgsConstructor
 @Table(name = "DiscussionTag")
 public class DiscussionTag extends BaseEntity {
     @Id
@@ -17,4 +23,11 @@ public class DiscussionTag extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "tag_id", nullable = false)
     private Tag tag;
+
+    @Builder
+    public DiscussionTag(Long id, Discussion discussion, Tag tag) {
+        this.id = id;
+        this.discussion = discussion;
+        this.tag = tag;
+    }
 }

--- a/src/main/java/com/hidiscuss/backend/entity/PointTransaction.java
+++ b/src/main/java/com/hidiscuss/backend/entity/PointTransaction.java
@@ -1,0 +1,36 @@
+package com.hidiscuss.backend.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "PointTransaction")
+public class PointTransaction extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "point_diff", nullable = false)
+    private Long pointDiff;
+
+    @Column(name = "reason", nullable = false)
+    private String reason;
+
+    @Builder
+    public PointTransaction(Long id, User user, Long pointDiff, String reason) {
+        this.id = id;
+        this.user = user;
+        this.pointDiff = pointDiff;
+        this.reason = reason;
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/entity/Review.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Review.java
@@ -1,0 +1,34 @@
+package com.hidiscuss.backend.entity;
+
+import javax.persistence.*;
+
+@Entity
+@Table(
+        name = "Review",
+        uniqueConstraints = @UniqueConstraint(
+                columnNames = {"reviewer_id", "discussion_id", "type"})
+)
+public class Review extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "reviewer_id", nullable = false)
+    private User reviewer;
+
+    @ManyToOne
+    @JoinColumn(name = "discussion_id", nullable = false)
+    private Discussion discussion;
+
+    @Column(name = "accepted", nullable = false)
+    private Boolean accepted;
+
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private Type type;
+}

--- a/src/main/java/com/hidiscuss/backend/entity/Review.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Review.java
@@ -12,7 +12,7 @@ import javax.persistence.*;
 @Table(
         name = "Review",
         uniqueConstraints = @UniqueConstraint(
-                columnNames = {"reviewer_id", "discussion_id", "reviwe_type"})
+                columnNames = {"reviewer_id", "discussion_id", "review_type"})
 )
 public class Review extends BaseEntity {
     @Id
@@ -28,23 +28,23 @@ public class Review extends BaseEntity {
     @JoinColumn(name = "discussion_id", nullable = false)
     private Discussion discussion;
 
-    @Column(name = "accepted", nullable = false)
+    @Column(columnDefinition ="boolean default false", name = "accepted", nullable = false)
     private Boolean accepted;
 
     @Column(name = "content", nullable = false)
     private String content;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "reviwe_type", nullable = false)
-    private ReviewType reviweType;
+    @Column(name = "review_type", nullable = false)
+    private ReviewType reviewType;
 
     @Builder
-    public Review(Long id, User reviewer, Discussion discussion, Boolean accepted, String content, ReviewType reviweType) {
+    public Review(Long id, User reviewer, Discussion discussion, Boolean accepted, String content, ReviewType reviewType) {
         this.id = id;
         this.reviewer = reviewer;
         this.discussion = discussion;
         this.accepted = accepted;
         this.content = content;
-        this.reviweType = reviweType;
+        this.reviewType = reviewType;
     }
 }

--- a/src/main/java/com/hidiscuss/backend/entity/Review.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Review.java
@@ -1,8 +1,14 @@
 package com.hidiscuss.backend.entity;
 
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import javax.persistence.*;
 
 @Entity
+@Getter
+@NoArgsConstructor
 @Table(
         name = "Review",
         uniqueConstraints = @UniqueConstraint(
@@ -31,4 +37,14 @@ public class Review extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "type", nullable = false)
     private Type type;
+
+    @Builder
+    public Review(Long id, User reviewer, Discussion discussion, Boolean accepted, String content, Type type) {
+        this.id = id;
+        this.reviewer = reviewer;
+        this.discussion = discussion;
+        this.accepted = accepted;
+        this.content = content;
+        this.type = type;
+    }
 }

--- a/src/main/java/com/hidiscuss/backend/entity/Review.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Review.java
@@ -12,7 +12,7 @@ import javax.persistence.*;
 @Table(
         name = "Review",
         uniqueConstraints = @UniqueConstraint(
-                columnNames = {"reviewer_id", "discussion_id", "type"})
+                columnNames = {"reviewer_id", "discussion_id", "reviwe_type"})
 )
 public class Review extends BaseEntity {
     @Id
@@ -35,16 +35,16 @@ public class Review extends BaseEntity {
     private String content;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "type", nullable = false)
-    private Type type;
+    @Column(name = "reviwe_type", nullable = false)
+    private ReviewType reviweType;
 
     @Builder
-    public Review(Long id, User reviewer, Discussion discussion, Boolean accepted, String content, Type type) {
+    public Review(Long id, User reviewer, Discussion discussion, Boolean accepted, String content, ReviewType reviweType) {
         this.id = id;
         this.reviewer = reviewer;
         this.discussion = discussion;
         this.accepted = accepted;
         this.content = content;
-        this.type = type;
+        this.reviweType = reviweType;
     }
 }

--- a/src/main/java/com/hidiscuss/backend/entity/ReviewDiff.java
+++ b/src/main/java/com/hidiscuss/backend/entity/ReviewDiff.java
@@ -1,0 +1,27 @@
+package com.hidiscuss.backend.entity;
+
+import javax.persistence.*;
+import java.security.spec.ECField;
+
+@Entity
+@Table(name = "ReviewDiff")
+public class ReviewDiff extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "review_id", nullable = false)
+    private Review review;
+
+    @ManyToOne
+    @JoinColumn(name = "discussion_code_id", nullable = false)
+    private DiscussionCode discussionCode;
+
+    @Column(name = "comment")
+    private String comment;
+
+    @Column(name = "updated_code", nullable = false)
+    private String updatedCode;
+}

--- a/src/main/java/com/hidiscuss/backend/entity/ReviewDiff.java
+++ b/src/main/java/com/hidiscuss/backend/entity/ReviewDiff.java
@@ -1,9 +1,14 @@
 package com.hidiscuss.backend.entity;
 
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import javax.persistence.*;
-import java.security.spec.ECField;
 
 @Entity
+@Getter
+@NoArgsConstructor
 @Table(name = "ReviewDiff")
 public class ReviewDiff extends BaseEntity {
     @Id
@@ -24,4 +29,13 @@ public class ReviewDiff extends BaseEntity {
 
     @Column(name = "updated_code", nullable = false)
     private String updatedCode;
+
+    @Builder
+    public ReviewDiff(Long id, Review review, DiscussionCode discussionCode, String comment, String updatedCode) {
+        this.id = id;
+        this.review = review;
+        this.discussionCode = discussionCode;
+        this.comment = comment;
+        this.updatedCode = updatedCode;
+    }
 }

--- a/src/main/java/com/hidiscuss/backend/entity/ReviewReservation.java
+++ b/src/main/java/com/hidiscuss/backend/entity/ReviewReservation.java
@@ -1,0 +1,38 @@
+package com.hidiscuss.backend.entity;
+
+import javax.persistence.*;
+import java.sql.Timestamp;
+
+@Entity
+@Table(name = "ReviewReservation")
+public class ReviewReservation extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "reviewer_id", nullable = false)
+    private User reviewer;
+
+    @ManyToOne
+    @JoinColumn(name = "reviwe_id", nullable = false)
+    private Review review;
+
+    @ManyToOne
+    @JoinColumn(name = "discussion_id", nullable = false)
+    private Discussion discussion;
+
+    @Column(name = "review_date", nullable = false)
+    private Timestamp reviewDate;
+
+    @Column(name = "reviwer_participated", nullable = false)
+    private Boolean reviwerParticipated;
+
+    @Column(name = "reviwee_participated", nullable = false)
+    private Boolean reviweeParticipated;
+
+    @Column(name = "progressed", nullable = false)
+    private Boolean progressed;
+
+}

--- a/src/main/java/com/hidiscuss/backend/entity/ReviewReservation.java
+++ b/src/main/java/com/hidiscuss/backend/entity/ReviewReservation.java
@@ -1,9 +1,15 @@
 package com.hidiscuss.backend.entity;
 
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import javax.persistence.*;
 import java.sql.Timestamp;
 
 @Entity
+@Getter
+@NoArgsConstructor
 @Table(name = "ReviewReservation")
 public class ReviewReservation extends BaseEntity {
     @Id
@@ -35,4 +41,15 @@ public class ReviewReservation extends BaseEntity {
     @Column(name = "progressed", nullable = false)
     private Boolean progressed;
 
+    @Builder
+    public ReviewReservation(Long id, User reviewer, Review review, Discussion discussion, Timestamp reviewDate, Boolean reviwerParticipated, Boolean reviweeParticipated, Boolean progressed) {
+        this.id = id;
+        this.reviewer = reviewer;
+        this.review = review;
+        this.discussion = discussion;
+        this.reviewDate = reviewDate;
+        this.reviwerParticipated = reviwerParticipated;
+        this.reviweeParticipated = reviweeParticipated;
+        this.progressed = progressed;
+    }
 }

--- a/src/main/java/com/hidiscuss/backend/entity/ReviewReservation.java
+++ b/src/main/java/com/hidiscuss/backend/entity/ReviewReservation.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -22,7 +22,7 @@ public class ReviewReservation extends BaseEntity {
     private User reviewer;
 
     @ManyToOne
-    @JoinColumn(name = "reviwe_id", nullable = false)
+    @JoinColumn(name = "review_id", nullable = true)
     private Review review;
 
     @ManyToOne
@@ -30,26 +30,26 @@ public class ReviewReservation extends BaseEntity {
     private Discussion discussion;
 
     @Column(name = "review_date", nullable = false)
-    private Timestamp reviewDate;
+    private LocalDateTime reviewDate;
 
-    @Column(name = "reviwer_participated", nullable = false)
-    private Boolean reviwerParticipated;
+    @Column(columnDefinition ="boolean default false", name = "reviewer_participated", nullable = false)
+    private Boolean reviewerParticipated;
 
-    @Column(name = "reviwee_participated", nullable = false)
-    private Boolean reviweeParticipated;
+    @Column(columnDefinition ="boolean default false", name = "reviewee_participated", nullable = false)
+    private Boolean revieweeParticipated;
 
-    @Column(name = "progressed", nullable = false)
-    private Boolean progressed;
+    @Column(columnDefinition ="boolean default false", name = "isdone", nullable = false)
+    private Boolean isdone;
 
     @Builder
-    public ReviewReservation(Long id, User reviewer, Review review, Discussion discussion, Timestamp reviewDate, Boolean reviwerParticipated, Boolean reviweeParticipated, Boolean progressed) {
+    public ReviewReservation(Long id, User reviewer, Review review, Discussion discussion, LocalDateTime reviewDate, Boolean reviewerParticipated, Boolean revieweeParticipated, Boolean isdone) {
         this.id = id;
         this.reviewer = reviewer;
         this.review = review;
         this.discussion = discussion;
         this.reviewDate = reviewDate;
-        this.reviwerParticipated = reviwerParticipated;
-        this.reviweeParticipated = reviweeParticipated;
-        this.progressed = progressed;
+        this.reviewerParticipated = reviewerParticipated;
+        this.revieweeParticipated = revieweeParticipated;
+        this.isdone = isdone;
     }
 }

--- a/src/main/java/com/hidiscuss/backend/entity/ReviewThread.java
+++ b/src/main/java/com/hidiscuss/backend/entity/ReviewThread.java
@@ -1,8 +1,14 @@
 package com.hidiscuss.backend.entity;
 
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import javax.persistence.*;
 
 @Entity
+@Getter
+@NoArgsConstructor
 @Table(name = "ReviewThread")
 public class ReviewThread extends BaseEntity {
     @Id
@@ -20,4 +26,12 @@ public class ReviewThread extends BaseEntity {
 
     @Column(name = "content", nullable = false)
     private String content;
+
+    @Builder
+    public ReviewThread(Long id, User user, Review review, String content) {
+        this.id = id;
+        this.user = user;
+        this.review = review;
+        this.content = content;
+    }
 }

--- a/src/main/java/com/hidiscuss/backend/entity/ReviewThread.java
+++ b/src/main/java/com/hidiscuss/backend/entity/ReviewThread.java
@@ -1,0 +1,23 @@
+package com.hidiscuss.backend.entity;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "ReviewThread")
+public class ReviewThread extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "review_id", nullable = false)
+    private Review review;
+
+    @Column(name = "content", nullable = false)
+    private String content;
+}

--- a/src/main/java/com/hidiscuss/backend/entity/ReviewType.java
+++ b/src/main/java/com/hidiscuss/backend/entity/ReviewType.java
@@ -1,11 +1,11 @@
 package com.hidiscuss.backend.entity;
 
-public enum Type {
+public enum ReviewType {
     LIVE(0), COMMENT(1);
 
     private int id;
 
-    Type(int id) {
+    ReviewType(int id) {
         this.id = id;
     }
 

--- a/src/main/java/com/hidiscuss/backend/entity/Reward.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Reward.java
@@ -1,0 +1,33 @@
+package com.hidiscuss.backend.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "Reward")
+public class Reward{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.ORDINAL)
+    @Column(name = "reward_type", nullable = false)
+    private RewardType rewardType;
+
+    @Builder
+    public Reward(Long id, User user, RewardType rewardType) {
+        this.id = id;
+        this.user = user;
+        this.rewardType = rewardType;
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/entity/RewardType.java
+++ b/src/main/java/com/hidiscuss/backend/entity/RewardType.java
@@ -1,0 +1,15 @@
+package com.hidiscuss.backend.entity;
+
+public enum RewardType {
+    BADGE(0), PRIORITY(1);
+
+    private int id;
+
+    RewardType(int id) {
+        this.id = id;
+    }
+
+    public int getId() {
+        return id;
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/entity/State.java
+++ b/src/main/java/com/hidiscuss/backend/entity/State.java
@@ -1,5 +1,15 @@
 package com.hidiscuss.backend.entity;
 
 public enum State {
-    NOT_REVIEWED, REVIEWING, COMPLETED;
+    NOT_REVIEWED(0), REVIEWING(1), COMPLETED(2);
+
+    private int id;
+
+    State(int id) {
+        this.id = id;
+    }
+
+    public int getId() {
+        return id;
+    }
 }

--- a/src/main/java/com/hidiscuss/backend/entity/State.java
+++ b/src/main/java/com/hidiscuss/backend/entity/State.java
@@ -1,0 +1,5 @@
+package com.hidiscuss.backend.entity;
+
+public enum State {
+    NOT_REVIEWED, REVIEWING, COMPLETED;
+}

--- a/src/main/java/com/hidiscuss/backend/entity/Status.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Status.java
@@ -1,0 +1,5 @@
+package com.hidiscuss.backend.entity;
+
+public enum Status {
+    ADDED, MODIFIED, REMOVED;
+}

--- a/src/main/java/com/hidiscuss/backend/entity/Status.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Status.java
@@ -1,5 +1,15 @@
 package com.hidiscuss.backend.entity;
 
 public enum Status {
-    ADDED, MODIFIED, REMOVED;
+    ADDED(0), MODIFIED(1), REMOVED(2);
+
+    private int id;
+
+    Status(int id) {
+        this.id = id;
+    }
+
+    public int getId() {
+        return id;
+    }
 }

--- a/src/main/java/com/hidiscuss/backend/entity/Tag.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Tag.java
@@ -1,0 +1,15 @@
+package com.hidiscuss.backend.entity;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "Tag")
+public class Tag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+}

--- a/src/main/java/com/hidiscuss/backend/entity/Tag.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Tag.java
@@ -1,8 +1,14 @@
 package com.hidiscuss.backend.entity;
 
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import javax.persistence.*;
 
 @Entity
+@Getter
+@NoArgsConstructor
 @Table(name = "Tag")
 public class Tag {
     @Id
@@ -12,4 +18,10 @@ public class Tag {
 
     @Column(name = "name", nullable = false)
     private String name;
+
+    @Builder
+    public Tag(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
 }

--- a/src/main/java/com/hidiscuss/backend/entity/Type.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Type.java
@@ -1,5 +1,15 @@
 package com.hidiscuss.backend.entity;
 
 public enum Type {
-    LIVE, COMMENT;
+    LIVE(0), COMMENT(1);
+
+    private int id;
+
+    Type(int id) {
+        this.id = id;
+    }
+
+    public int getId() {
+        return id;
+    }
 }

--- a/src/main/java/com/hidiscuss/backend/entity/Type.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Type.java
@@ -1,0 +1,5 @@
+package com.hidiscuss.backend.entity;
+
+public enum Type {
+    LIVE, COMMENT;
+}

--- a/src/main/java/com/hidiscuss/backend/entity/User.java
+++ b/src/main/java/com/hidiscuss/backend/entity/User.java
@@ -14,20 +14,21 @@ import java.util.List;
 public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
     private Long id;
 
-    @Column(name = "name")
+    @Column(name = "name", nullable = false)
     private String name;
 
-    @Column(name = "email")
+    @Column(name = "email", nullable = false)
     private String email;
 
-    @Column(name = "access_token")
+    @Column(name = "access_token", nullable = false)
     private String accessToken;
 
-    @Column(name = "refresh_token")
+    @Column(name = "refresh_token", nullable = false)
     private String refresh_token;
 
-    @Column(name = "point")
+    @Column(name = "point", nullable = false)
     private Long point;
 }

--- a/src/main/java/com/hidiscuss/backend/entity/User.java
+++ b/src/main/java/com/hidiscuss/backend/entity/User.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 @Entity
 @Table(name = "User")
-public class User {
+public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -32,5 +32,5 @@ public class User {
     private Long point;
 
     @OneToMany(mappedBy = "user")
-    private List<Discussion> discussion = new ArrayList<>();
+    private List<Discussion> discussions = new ArrayList<>();
 }

--- a/src/main/java/com/hidiscuss/backend/entity/User.java
+++ b/src/main/java/com/hidiscuss/backend/entity/User.java
@@ -30,7 +30,4 @@ public class User extends BaseEntity {
 
     @Column(name = "point")
     private Long point;
-
-    @OneToMany(mappedBy = "user")
-    private List<Discussion> discussions = new ArrayList<>();
 }

--- a/src/main/java/com/hidiscuss/backend/entity/User.java
+++ b/src/main/java/com/hidiscuss/backend/entity/User.java
@@ -1,15 +1,14 @@
 package com.hidiscuss.backend.entity;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
+@Getter
+@NoArgsConstructor
 @Table(name = "User")
 public class User extends BaseEntity {
     @Id
@@ -31,4 +30,14 @@ public class User extends BaseEntity {
 
     @Column(name = "point", nullable = false)
     private Long point;
+
+    @Builder
+    public User(Long id, String name, String email, String accessToken, String refresh_token, Long point) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+        this.accessToken = accessToken;
+        this.refresh_token = refresh_token;
+        this.point = point;
+    }
 }

--- a/src/main/java/com/hidiscuss/backend/entity/User.java
+++ b/src/main/java/com/hidiscuss/backend/entity/User.java
@@ -16,7 +16,7 @@ public class User extends BaseEntity {
     @Column(name = "id", nullable = false)
     private Long id;
 
-    @Column(name = "name", nullable = false)
+    @Column(name = "username", nullable = false)
     private String name;
 
     @Column(name = "email", nullable = false)

--- a/src/main/java/com/hidiscuss/backend/entity/User.java
+++ b/src/main/java/com/hidiscuss/backend/entity/User.java
@@ -6,22 +6,31 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
-@Table(name = "user")
 @Entity
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
-@Getter
+@Table(name = "User")
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "idx", nullable = false)
-    private Long idx;
+    private Long id;
 
     @Column(name = "name")
     private String name;
 
     @Column(name = "email")
     private String email;
+
+    @Column(name = "access_token")
+    private String accessToken;
+
+    @Column(name = "refresh_token")
+    private String refresh_token;
+
+    @Column(name = "point")
+    private Long point;
+
+    @OneToMany(mappedBy = "user")
+    private List<Discussion> discussion = new ArrayList<>();
 }

--- a/src/main/java/com/hidiscuss/backend/repository/DiscussionCodeRepository.java
+++ b/src/main/java/com/hidiscuss/backend/repository/DiscussionCodeRepository.java
@@ -1,0 +1,7 @@
+package com.hidiscuss.backend.repository;
+
+import com.hidiscuss.backend.entity.DiscussionCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DiscussionCodeRepository extends JpaRepository<DiscussionCode, Long>, DiscussionCodeRepositoryCustom {
+}

--- a/src/main/java/com/hidiscuss/backend/repository/DiscussionCodeRepositoryCustom.java
+++ b/src/main/java/com/hidiscuss/backend/repository/DiscussionCodeRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.hidiscuss.backend.repository;
+
+public interface DiscussionCodeRepositoryCustom {
+}

--- a/src/main/java/com/hidiscuss/backend/repository/DiscussionCodeRepositoryImpl.java
+++ b/src/main/java/com/hidiscuss/backend/repository/DiscussionCodeRepositoryImpl.java
@@ -1,0 +1,13 @@
+package com.hidiscuss.backend.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class DiscussionCodeRepositoryImpl {
+    private final JPAQueryFactory queryFactory;
+
+    public DiscussionCodeRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/repository/DiscussionRepository.java
+++ b/src/main/java/com/hidiscuss/backend/repository/DiscussionRepository.java
@@ -1,0 +1,7 @@
+package com.hidiscuss.backend.repository;
+
+import com.hidiscuss.backend.entity.Discussion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DiscussionRepository extends JpaRepository<Discussion, Long>, DiscussionRepositoryCustom {
+}

--- a/src/main/java/com/hidiscuss/backend/repository/DiscussionRepositoryCustom.java
+++ b/src/main/java/com/hidiscuss/backend/repository/DiscussionRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.hidiscuss.backend.repository;
+
+public interface DiscussionRepositoryCustom {
+}

--- a/src/main/java/com/hidiscuss/backend/repository/DiscussionRepositoryImpl.java
+++ b/src/main/java/com/hidiscuss/backend/repository/DiscussionRepositoryImpl.java
@@ -1,0 +1,13 @@
+package com.hidiscuss.backend.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class DiscussionRepositoryImpl {
+    private final JPAQueryFactory queryFactory;
+
+    public DiscussionRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/repository/DiscussionTagRepository.java
+++ b/src/main/java/com/hidiscuss/backend/repository/DiscussionTagRepository.java
@@ -1,0 +1,7 @@
+package com.hidiscuss.backend.repository;
+
+import com.hidiscuss.backend.entity.DiscussionTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DiscussionTagRepository extends JpaRepository<DiscussionTag, Long>, DiscussionTagRepositoryCustom {
+}

--- a/src/main/java/com/hidiscuss/backend/repository/DiscussionTagRepositoryCustom.java
+++ b/src/main/java/com/hidiscuss/backend/repository/DiscussionTagRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.hidiscuss.backend.repository;
+
+public interface DiscussionTagRepositoryCustom {
+}

--- a/src/main/java/com/hidiscuss/backend/repository/DiscussionTagRepositoryImpl.java
+++ b/src/main/java/com/hidiscuss/backend/repository/DiscussionTagRepositoryImpl.java
@@ -1,0 +1,13 @@
+package com.hidiscuss.backend.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class DiscussionTagRepositoryImpl {
+    private final JPAQueryFactory queryFactory;
+
+    public DiscussionTagRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/repository/PointTransactionRepository.java
+++ b/src/main/java/com/hidiscuss/backend/repository/PointTransactionRepository.java
@@ -1,0 +1,7 @@
+package com.hidiscuss.backend.repository;
+
+import com.hidiscuss.backend.entity.PointTransaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PointTransactionRepository extends JpaRepository<PointTransaction, Long>, PointTransactionRepositoryCustom {
+}

--- a/src/main/java/com/hidiscuss/backend/repository/PointTransactionRepositoryCustom.java
+++ b/src/main/java/com/hidiscuss/backend/repository/PointTransactionRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.hidiscuss.backend.repository;
+
+public interface PointTransactionRepositoryCustom {
+}

--- a/src/main/java/com/hidiscuss/backend/repository/PointTransactionRepositoryImpl.java
+++ b/src/main/java/com/hidiscuss/backend/repository/PointTransactionRepositoryImpl.java
@@ -1,0 +1,13 @@
+package com.hidiscuss.backend.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class PointTransactionRepositoryImpl {
+    private final JPAQueryFactory queryFactory;
+
+    public PointTransactionRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/repository/ReviewDiffRepository.java
+++ b/src/main/java/com/hidiscuss/backend/repository/ReviewDiffRepository.java
@@ -1,0 +1,7 @@
+package com.hidiscuss.backend.repository;
+
+import com.hidiscuss.backend.entity.ReviewDiff;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewDiffRepository extends JpaRepository<ReviewDiff, Long>, ReviewDiffRepositoryCustom {
+}

--- a/src/main/java/com/hidiscuss/backend/repository/ReviewDiffRepositoryCustom.java
+++ b/src/main/java/com/hidiscuss/backend/repository/ReviewDiffRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.hidiscuss.backend.repository;
+
+public interface ReviewDiffRepositoryCustom {
+}

--- a/src/main/java/com/hidiscuss/backend/repository/ReviewDiffRepositoryImpl.java
+++ b/src/main/java/com/hidiscuss/backend/repository/ReviewDiffRepositoryImpl.java
@@ -1,0 +1,13 @@
+package com.hidiscuss.backend.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ReviewDiffRepositoryImpl {
+    private final JPAQueryFactory queryFactory;
+
+    public ReviewDiffRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/repository/ReviewRepository.java
+++ b/src/main/java/com/hidiscuss/backend/repository/ReviewRepository.java
@@ -1,0 +1,7 @@
+package com.hidiscuss.backend.repository;
+
+import com.hidiscuss.backend.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRepositoryCustom {
+}

--- a/src/main/java/com/hidiscuss/backend/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/com/hidiscuss/backend/repository/ReviewRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.hidiscuss.backend.repository;
+
+public interface ReviewRepositoryCustom {
+}

--- a/src/main/java/com/hidiscuss/backend/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/hidiscuss/backend/repository/ReviewRepositoryImpl.java
@@ -1,0 +1,13 @@
+package com.hidiscuss.backend.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ReviewRepositoryImpl {
+    private final JPAQueryFactory queryFactory;
+
+    public ReviewRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/repository/ReviewReservationRepository.java
+++ b/src/main/java/com/hidiscuss/backend/repository/ReviewReservationRepository.java
@@ -1,0 +1,7 @@
+package com.hidiscuss.backend.repository;
+
+import com.hidiscuss.backend.entity.ReviewReservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewReservationRepository extends JpaRepository<ReviewReservation, Long>, ReviewReservationRepositoryCustom {
+}

--- a/src/main/java/com/hidiscuss/backend/repository/ReviewReservationRepositoryCustom.java
+++ b/src/main/java/com/hidiscuss/backend/repository/ReviewReservationRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.hidiscuss.backend.repository;
+
+public interface ReviewReservationRepositoryCustom {
+}

--- a/src/main/java/com/hidiscuss/backend/repository/ReviewReservationRepositoryImpl.java
+++ b/src/main/java/com/hidiscuss/backend/repository/ReviewReservationRepositoryImpl.java
@@ -1,0 +1,13 @@
+package com.hidiscuss.backend.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ReviewReservationRepositoryImpl {
+    private final JPAQueryFactory queryFactory;
+
+    public ReviewReservationRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/repository/ReviewThreadRepository.java
+++ b/src/main/java/com/hidiscuss/backend/repository/ReviewThreadRepository.java
@@ -1,0 +1,7 @@
+package com.hidiscuss.backend.repository;
+
+import com.hidiscuss.backend.entity.ReviewThread;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewThreadRepository extends JpaRepository<ReviewThread, Long>, ReviewThreadRepositoryCustom {
+}

--- a/src/main/java/com/hidiscuss/backend/repository/ReviewThreadRepositoryCustom.java
+++ b/src/main/java/com/hidiscuss/backend/repository/ReviewThreadRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.hidiscuss.backend.repository;
+
+public interface ReviewThreadRepositoryCustom {
+}

--- a/src/main/java/com/hidiscuss/backend/repository/ReviewThreadRepositoryImpl.java
+++ b/src/main/java/com/hidiscuss/backend/repository/ReviewThreadRepositoryImpl.java
@@ -1,0 +1,13 @@
+package com.hidiscuss.backend.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ReviewThreadRepositoryImpl {
+    private final JPAQueryFactory queryFactory;
+
+    public ReviewThreadRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/repository/RewardRepository.java
+++ b/src/main/java/com/hidiscuss/backend/repository/RewardRepository.java
@@ -1,0 +1,7 @@
+package com.hidiscuss.backend.repository;
+
+import com.hidiscuss.backend.entity.Reward;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RewardRepository extends JpaRepository<Reward, Long>, RewardRepositoryCustom {
+}

--- a/src/main/java/com/hidiscuss/backend/repository/RewardRepositoryCustom.java
+++ b/src/main/java/com/hidiscuss/backend/repository/RewardRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.hidiscuss.backend.repository;
+
+public interface RewardRepositoryCustom {
+}

--- a/src/main/java/com/hidiscuss/backend/repository/RewardRepositoryImpl.java
+++ b/src/main/java/com/hidiscuss/backend/repository/RewardRepositoryImpl.java
@@ -1,0 +1,13 @@
+package com.hidiscuss.backend.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class RewardRepositoryImpl {
+    private final JPAQueryFactory queryFactory;
+
+    public RewardRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/repository/TagRepository.java
+++ b/src/main/java/com/hidiscuss/backend/repository/TagRepository.java
@@ -1,0 +1,7 @@
+package com.hidiscuss.backend.repository;
+
+import com.hidiscuss.backend.entity.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagRepository extends JpaRepository<Tag, Long>, TagRepositoryCustom {
+}

--- a/src/main/java/com/hidiscuss/backend/repository/TagRepositoryCustom.java
+++ b/src/main/java/com/hidiscuss/backend/repository/TagRepositoryCustom.java
@@ -1,0 +1,6 @@
+package com.hidiscuss.backend.repository;
+
+import org.springframework.stereotype.Repository;
+
+public interface TagRepositoryCustom {
+}

--- a/src/main/java/com/hidiscuss/backend/repository/TagRepositoryImpl.java
+++ b/src/main/java/com/hidiscuss/backend/repository/TagRepositoryImpl.java
@@ -1,0 +1,13 @@
+package com.hidiscuss.backend.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class TagRepositoryImpl implements TagRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    public TagRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/hidiscuss/backend/repository/UserRepositoryImpl.java
@@ -9,7 +9,6 @@ import java.util.List;
 
 @Repository
 public class UserRepositoryImpl implements UserRepositoryCustom {
-
     private final JPAQueryFactory queryFactory;
 
     public UserRepositoryImpl(JPAQueryFactory queryFactory) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,12 @@
+# DataSource
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/hidiscuss?autoReconnect=true
+    hikari:
+      username: root
+      password: 17181718
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create
+    generate-ddl: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,6 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: none
-    # ddl-auto: create
+     # ddl-auto: none
+      ddl-auto: create
     generate-ddl: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,5 +8,6 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
+    # ddl-auto: create
     generate-ddl: true


### PR DESCRIPTION
## 티켓
[CAPS-66](https://2022springcapstone.atlassian.net/browse/CAPS-66)

## 작업 내용
- [x] entity 작성
- [x] repository, repositoryImpl, repositoryCustom 작성
- [x] application.properties -> .yml로 변경

## 논의 사항

- User의 username -> name으로 변경
- Discussion-user: 양방향 매핑
- Review-Discussion: 양방향 매핑
- Discussion의 state -> discussionState로 변경?
- ReviewReservation의 progressed -> isdone 등으로 변경?
- ReviewDiff의 comment가 nullable인 이유
- pointTransaction에서 reason의 의미


## 전달 사항
- Review와 Reward의 type enum 변수명이 겹쳐서 각각 reviewType, rewardType으로 변경했습니다.
- Json을 java에서 어떤 데이터타입으로 쓸지 모르겠어서 일단 String으로 두었습니다.
![ERD_DDL ver](https://user-images.githubusercontent.com/43488326/160923682-4a120fb3-75e4-45a7-89e7-317116a3c32c.png)

