### PR TITLE
CAPS-104 :Discussion 추가 관련 API문서/Controller 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,9 @@ dependencies {
 	// Swagger
 	implementation 'io.springfox:springfox-boot-starter:3.0.0'
 	implementation 'io.springfox:springfox-swagger-ui:3.0.0'
+
+	// Github REST API Client
+	implementation 'org.kohsuke:github-api:1.303'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hidiscuss/backend/config/WebMvcConfig.java
+++ b/src/main/java/com/hidiscuss/backend/config/WebMvcConfig.java
@@ -1,0 +1,26 @@
+package com.hidiscuss.backend.config;
+
+import com.hidiscuss.backend.config.interceptor.GithubInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new GithubInterceptor()).order(1); // TODO : order 수정 => after authentication
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("*")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*");
+             //   .allowCredentials(true);
+    }
+
+}

--- a/src/main/java/com/hidiscuss/backend/config/interceptor/GithubInterceptor.java
+++ b/src/main/java/com/hidiscuss/backend/config/interceptor/GithubInterceptor.java
@@ -1,0 +1,51 @@
+package com.hidiscuss.backend.config.interceptor;
+
+import com.hidiscuss.backend.utils.GithubContext;
+import org.kohsuke.github.GHRateLimit;
+import org.kohsuke.github.GitHub;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+public class GithubInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Object handler
+    ) throws Exception {
+        GitHub github = GitHub.connectAnonymously();
+        //Github github = new GitHubBuilder().withOAuthToken("request...").build();
+        // TODO : github instance based on access token
+
+        GHRateLimit rateLimit = github.getRateLimit();
+        if(rateLimit.getRemaining() < 1) {
+            throw new RuntimeException("Github API rate limit exceeded"); // TODO : custom exception
+        }
+        GithubContext.setInstance(github);
+        return true;
+    }
+
+    @Override
+    public void postHandle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Object handler,
+            ModelAndView modelAndView
+    ) throws Exception {
+        GithubContext.clear();
+    }
+
+
+    @Override
+    public void afterCompletion(
+            HttpServletRequest request, HttpServletResponse response,
+            Object obj, Exception e)
+            throws Exception {
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/controller/CreateDiscussionRequestDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/CreateDiscussionRequestDto.java
@@ -1,2 +1,0 @@
-package com.hidiscuss.backend.controller;public class CreateDiscussionRequestDto {
-}

--- a/src/main/java/com/hidiscuss/backend/controller/DiscussionController.java
+++ b/src/main/java/com/hidiscuss/backend/controller/DiscussionController.java
@@ -1,2 +1,44 @@
-package com.hidiscuss.backend.controller;public class DiscussionController {
+package com.hidiscuss.backend.controller;
+
+import com.hidiscuss.backend.controller.dto.CreateDiscussionRequestDto;
+import com.hidiscuss.backend.controller.dto.DiscussionResponseDto;
+import io.swagger.annotations.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/discussion")
+public class DiscussionController {
+    //private final DiscussionService discussionService;
+
+    //public DiscussionController(DiscussionService discussionService) {
+    //    this.discussionService = discussionService;
+    //}
+
+    @PostMapping("/")
+    @ResponseStatus(HttpStatus.CREATED)
+    @ApiOperation(value = "Discussion 생성")
+    @ApiResponses({
+            @ApiResponse(code = 201, message = "새로운 Discussion 생성 성공"),
+            @ApiResponse(code = 400, message = "잘못된 요청"),
+            @ApiResponse(code = 500, message = "서버 오류")
+    })
+    public DiscussionResponseDto createDiscussion(
+            @RequestBody @Valid CreateDiscussionRequestDto createDiscussionRequestDto) {
+        if (createDiscussionRequestDto.isDirectDiscussion()) {
+            if (createDiscussionRequestDto.codes == null) {
+                throw new IllegalArgumentException("코드가 없습니다.");
+            }
+        } else {
+            if (createDiscussionRequestDto.gitNodeId == null) {
+                throw new IllegalArgumentException("gitNodeId가 없습니다.");
+            }
+        }
+        return DiscussionResponseDto.fromEntity(CreateDiscussionRequestDto.toEntity(createDiscussionRequestDto));
+        //discussionService.createDiscussion(createDiscussionRequestDto);
+    }
 }
+
+

--- a/src/main/java/com/hidiscuss/backend/controller/GithubController.java
+++ b/src/main/java/com/hidiscuss/backend/controller/GithubController.java
@@ -1,12 +1,10 @@
 package com.hidiscuss.backend.controller;
 
 import com.hidiscuss.backend.controller.dto.GHCommitResponseDto;
+import com.hidiscuss.backend.controller.dto.GHPullRequestResponseDto;
 import com.hidiscuss.backend.controller.dto.GHRepositoryResponseDto;
 import com.hidiscuss.backend.utils.GithubContext;
-import org.kohsuke.github.GHCommit;
-import org.kohsuke.github.GHRepository;
-import org.kohsuke.github.GHUser;
-import org.kohsuke.github.GitHub;
+import org.kohsuke.github.*;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -40,6 +38,20 @@ public class GithubController {
             GHRepository repo = github.getRepositoryById(repoId);
             List<GHCommit> commits = repo.listCommits().toList();
             return commits.stream().map(GHCommitResponseDto::fromGHCommit).collect(Collectors.toList());
+        } catch (Exception e) {
+            throw new RuntimeException(e); // TODO : custom exception
+        }
+    }
+
+    @GetMapping("/prs/{repoId}")
+    public List<GHPullRequestResponseDto> getPullRequests(
+            @PathVariable("repoId") Long repoId
+    ) {
+        GitHub github = GithubContext.getInstance();
+        try {
+            GHRepository repo = github.getRepositoryById(repoId);
+            List<GHPullRequest> pullRequests = repo.queryPullRequests().list().toList();
+            return pullRequests.stream().map(GHPullRequestResponseDto::fromGHPullRequest).collect(Collectors.toList());
         } catch (Exception e) {
             throw new RuntimeException(e); // TODO : custom exception
         }

--- a/src/main/java/com/hidiscuss/backend/controller/GithubController.java
+++ b/src/main/java/com/hidiscuss/backend/controller/GithubController.java
@@ -1,0 +1,47 @@
+package com.hidiscuss.backend.controller;
+
+import com.hidiscuss.backend.controller.dto.GHCommitResponseDto;
+import com.hidiscuss.backend.controller.dto.GHRepositoryResponseDto;
+import com.hidiscuss.backend.utils.GithubContext;
+import org.kohsuke.github.GHCommit;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GHUser;
+import org.kohsuke.github.GitHub;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/github")
+public class GithubController {
+
+    @GetMapping("/repos")
+    public List<GHRepositoryResponseDto> getRepo(
+    //        @RequestAttribute("github") GitHub github
+    ) {
+        GitHub github = GithubContext.getInstance();
+        try {
+            GHUser user = github.getUser("capstone-signal");
+            Map<String, GHRepository> repos = user.getRepositories();
+            return repos.values().stream().map(GHRepositoryResponseDto::fromGHRepository).collect(Collectors.toList());
+        } catch (Exception e) {
+            throw new RuntimeException(e); // TODO : custom exception
+        }
+    }
+
+    @GetMapping("/commits/{repoId}")
+    public List<GHCommitResponseDto> getCommits(
+            @PathVariable("repoId") Long repoId
+    ) {
+        GitHub github = GithubContext.getInstance();
+        try {
+            GHRepository repo = github.getRepositoryById(repoId);
+            List<GHCommit> commits = repo.listCommits().toList();
+            return commits.stream().map(GHCommitResponseDto::fromGHCommit).collect(Collectors.toList());
+        } catch (Exception e) {
+            throw new RuntimeException(e); // TODO : custom exception
+        }
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/hidiscuss/backend/controller/GlobalExceptionHandler.java
@@ -16,7 +16,15 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class) // Controller @Valid processing
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public String handleException(MethodArgumentNotValidException e) {
+        logger.warn(e.getMessage());
         return e.getBindingResult().getFieldError().getDefaultMessage(); // TODO : return proper error message
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String handleException(IllegalArgumentException e) {
+        logger.warn(e.getMessage());
+        return e.getMessage();
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/hidiscuss/backend/controller/dto/BaseResponseDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/BaseResponseDto.java
@@ -7,11 +7,11 @@ import java.time.LocalDateTime;
 
 @Getter
 public class BaseResponseDto {
-    private LocalDateTime created_at;
-    private LocalDateTime last_modified_at;
+    private LocalDateTime createdAt;
+    private LocalDateTime lastModifiedAt;
 
     public void setBaseResponse(BaseEntity entity) {
-        this.created_at = entity.getCreatedAt();
-        this.last_modified_at = entity.getLastModifiedAt();
+        this.createdAt = entity.getCreatedAt();
+        this.lastModifiedAt = entity.getLastModifiedAt();
     }
 }

--- a/src/main/java/com/hidiscuss/backend/controller/dto/CreateDiscussionCodeRequestDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/CreateDiscussionCodeRequestDto.java
@@ -1,0 +1,9 @@
+package com.hidiscuss.backend.controller.dto;
+
+public class CreateDiscussionCodeRequestDto {
+    public String filename;
+    public String content;
+    public int getLength() {
+        return content.length();
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/controller/dto/CreateDiscussionRequestDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/CreateDiscussionRequestDto.java
@@ -22,6 +22,8 @@ public class CreateDiscussionRequestDto {
     public String discussionType;
 
     @Nullable
+    public String gitRepositoryId;
+    @Nullable
     public String gitNodeId;
 
     @NotNull

--- a/src/main/java/com/hidiscuss/backend/controller/dto/CreateDiscussionRequestDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/CreateDiscussionRequestDto.java
@@ -1,0 +1,52 @@
+package com.hidiscuss.backend.controller.dto;
+
+import com.hidiscuss.backend.entity.Discussion;
+import com.hidiscuss.backend.entity.DiscussionState;
+import com.hidiscuss.backend.entity.LiveReviewAvailableTimes;
+import org.springframework.lang.Nullable;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import java.util.List;
+
+public class CreateDiscussionRequestDto {
+    @NotNull
+//    @Size(min = 1, max = 1234)
+    public String question;
+
+    @NotNull
+    public boolean liveReviewRequired = false;
+
+    @NotNull
+    @Pattern(regexp = "^(PR|COMMIT|DIRECT)$")
+    public String discussionType;
+
+    @Nullable
+    public String gitNodeId;
+
+    @NotNull
+    public LiveReviewAvailableTimes liveReviewAvailableTimes;
+
+    @Nullable
+    public boolean usePriority = false;
+
+    @NotNull
+    public List<Long> tagIds;
+
+    @Nullable
+    public List<CreateDiscussionCodeRequestDto> codes;
+
+    public static Discussion toEntity(CreateDiscussionRequestDto dto) {
+        return Discussion.builder()
+                .question(dto.question)
+                .liveReviewRequired(dto.liveReviewRequired)
+                .liveReviewAvailableTimes(dto.liveReviewAvailableTimes)
+                .priority(dto.usePriority ? 255L : 0L)
+                .state(DiscussionState.NOT_REVIEWED)
+                .build();
+    }
+
+    public boolean isDirectDiscussion() {
+        return this.discussionType.equals("DIRECT");
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/controller/dto/DiscussionResponseDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/DiscussionResponseDto.java
@@ -1,0 +1,33 @@
+package com.hidiscuss.backend.controller.dto;
+
+import com.hidiscuss.backend.entity.Discussion;
+import com.hidiscuss.backend.entity.LiveReviewAvailableTimes;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class DiscussionResponseDto extends BaseResponseDto {
+    private Long id;
+    private String question;
+    private Boolean liveReviewRequired;
+    private LiveReviewAvailableTimes liveReviewAvailableTimes;
+    private Long priority;
+    private int state;
+    private UserResponseDto user;
+    private List<TagResponseDto> tags;
+    public static DiscussionResponseDto fromEntity(Discussion entity) {
+        DiscussionResponseDto dto = new DiscussionResponseDto();
+        dto.setBaseResponse(entity);
+        dto.id = entity.getId();
+        dto.question = entity.getQuestion();
+        dto.liveReviewRequired = entity.getLiveReviewRequired();
+        dto.liveReviewAvailableTimes = entity.getLiveReviewAvailableTimes();
+        dto.priority = entity.getPriority();
+        dto.state = entity.getState().getId();
+        //dto.tags = entity.getTags().stream().map(TagResponseDto::fromEntity).collect(Collectors.toList());
+        //dto.user = UserResponseDto.fromEntity(entity.getUser());
+        return dto;
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/controller/dto/GHCommitResponseDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/GHCommitResponseDto.java
@@ -1,0 +1,36 @@
+package com.hidiscuss.backend.controller.dto;
+
+import antlr.MismatchedCharException;
+import lombok.Getter;
+import org.kohsuke.github.GHCommit;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@Getter
+public class GHCommitResponseDto {
+    private String sha;
+    private LocalDateTime date;
+    private String url;
+    private String message;
+
+    private GHCommitResponseDto(String sha, LocalDateTime date, String url, String message) {
+        this.sha = sha;
+        this.date = date;
+        this.url = url;
+        this.message = message;
+    }
+    public static GHCommitResponseDto fromGHCommit(GHCommit ghCommit) {
+        try {
+            GHCommit.ShortInfo shortInfo = ghCommit.getCommitShortInfo();
+            return new GHCommitResponseDto(ghCommit.getSHA1(),
+                    shortInfo.getCommitDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime(),
+                    ghCommit.getHtmlUrl().toString(),
+                    shortInfo.getMessage()
+            );
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/controller/dto/GHPullRequestResponseDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/GHPullRequestResponseDto.java
@@ -1,2 +1,26 @@
-package com.hidiscuss.backend.controller.dto;public class GHPullRequestResponseDto {
+package com.hidiscuss.backend.controller.dto;
+
+import lombok.Getter;
+import org.kohsuke.github.GHPullRequest;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class GHPullRequestResponseDto {
+    private Long id;
+    private String title;
+    private String url;
+
+    private GHPullRequestResponseDto(Long id, String title, String url) {
+        this.id = id;
+        this.title = title;
+        this.url = url;
+    }
+    public static GHPullRequestResponseDto fromGHPullRequest(GHPullRequest pullRequest) {
+        return new GHPullRequestResponseDto(
+                pullRequest.getId(),
+                pullRequest.getTitle(),
+                pullRequest.getHtmlUrl().toString()
+        );
+    }
 }

--- a/src/main/java/com/hidiscuss/backend/controller/dto/GHPullRequestResponseDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/GHPullRequestResponseDto.java
@@ -1,0 +1,2 @@
+package com.hidiscuss.backend.controller.dto;public class GHPullRequestResponseDto {
+}

--- a/src/main/java/com/hidiscuss/backend/controller/dto/GHRepositoryResponseDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/GHRepositoryResponseDto.java
@@ -1,0 +1,21 @@
+package com.hidiscuss.backend.controller.dto;
+
+import lombok.Getter;
+import org.kohsuke.github.GHRepository;
+
+@Getter
+public class GHRepositoryResponseDto {
+    private String id;
+    private String fullName;
+    private String url;
+
+    private GHRepositoryResponseDto(long id, String fullName, String url) {
+        this.id = String.valueOf(id);
+        this.fullName = fullName;
+        this.url = url;
+    }
+
+    public static GHRepositoryResponseDto fromGHRepository(GHRepository ghRepository) {
+        return new GHRepositoryResponseDto(ghRepository.getId(), ghRepository.getFullName(), ghRepository.getHtmlUrl().toString());
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/controller/dto/TagResponseDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/TagResponseDto.java
@@ -1,0 +1,19 @@
+package com.hidiscuss.backend.controller.dto;
+
+import com.hidiscuss.backend.entity.Tag;
+import lombok.Getter;
+
+@Getter
+public class TagResponseDto {
+    private Long id;
+    private String name;
+
+    private TagResponseDto(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+    static TagResponseDto fromEntity(Tag tag) {
+        TagResponseDto dto = new TagResponseDto(tag.getId(), tag.getName());
+        return dto;
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/entity/Discussion.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Discussion.java
@@ -30,14 +30,15 @@ public class Discussion extends BaseEntity {
     @Column(columnDefinition = "boolean default false", name = "live_review_required", nullable = false)
     private Boolean liveReviewRequired;
 
-    @Column(name = "live_review_available_times")
-    private String liveReviewAvailableTimes;
+    @Column(columnDefinition = "json default null", name = "live_review_available_times")
+    @Convert(converter = LiveReviewAvailableTimesConverter.class)
+    private LiveReviewAvailableTimes liveReviewAvailableTimes;
 
     @Column(columnDefinition = "bigint default 0", name = "priority", nullable = false)
     private Long priority;
 
     @Builder
-    public Discussion(Long id, DiscussionState state, User user, String question, Boolean liveReviewRequired, String liveReviewAvailableTimes, Long priority) {
+    public Discussion(Long id, DiscussionState state, User user, String question, Boolean liveReviewRequired, LiveReviewAvailableTimes liveReviewAvailableTimes, Long priority) {
         this.id = id;
         this.state = state;
         this.user = user;

--- a/src/main/java/com/hidiscuss/backend/entity/LiveReviewAvailableTimes.java
+++ b/src/main/java/com/hidiscuss/backend/entity/LiveReviewAvailableTimes.java
@@ -1,0 +1,17 @@
+package com.hidiscuss.backend.entity;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+public class LiveReviewAvailableTimes {
+    private List<LiveReviewAvailableTime> times;
+
+    @Getter
+    private static class LiveReviewAvailableTime {
+        private LocalDateTime start;
+        private LocalDateTime end;
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/entity/LiveReviewAvailableTimesConverter.java
+++ b/src/main/java/com/hidiscuss/backend/entity/LiveReviewAvailableTimesConverter.java
@@ -1,0 +1,38 @@
+package com.hidiscuss.backend.entity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+@Converter
+public class LiveReviewAvailableTimesConverter implements AttributeConverter<LiveReviewAvailableTimes, String> {
+    private static final Logger logger = LoggerFactory.getLogger(LiveReviewAvailableTimesConverter.class);
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    @Override
+    public String convertToDatabaseColumn(LiveReviewAvailableTimes attribute) {
+        String stringified = null;
+        try {
+            stringified = objectMapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            logger.error("Convert error", e);
+            throw new RuntimeException(e); // TODO : change to custom exception
+        }
+        return stringified;
+    }
+
+    @Override
+    public LiveReviewAvailableTimes convertToEntityAttribute(String dbData) {
+        LiveReviewAvailableTimes attribute = null;
+        try {
+            attribute = objectMapper.readValue(dbData, LiveReviewAvailableTimes.class);
+        } catch (JsonProcessingException e) {
+            logger.error("Convert error", e);
+            throw new RuntimeException(e); // TODO : change to custom exception
+        }
+        return attribute;
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/utils/GithubContext.java
+++ b/src/main/java/com/hidiscuss/backend/utils/GithubContext.java
@@ -1,0 +1,20 @@
+package com.hidiscuss.backend.utils;
+
+
+import org.kohsuke.github.GitHub;
+
+public class GithubContext {
+    private static final ThreadLocal<GitHub> context = new ThreadLocal<>();
+
+    public static GitHub getInstance() {
+        return context.get();
+    }
+
+    public static void clear() {
+        context.remove();
+    }
+
+    public static void setInstance(GitHub gitHub) {
+        context.set(gitHub);
+    }
+}


### PR DESCRIPTION
### 티켓
[CAPS-104](https://2022springcapstone.atlassian.net/browse/CAPS-104?atlOrigin=eyJpIjoiYTFkNTQ5NWIzZDY5NDQyOWEyYjhhZjliMGRkNWU1ZGYiLCJwIjoiaiJ9)

### 추가 사항
- `GithubController`, `GithubInterceptor` : Github API 관련 추가
- `GH__Response` : 클라이언트에 내려줄 Github 리소스(Repository, Commit, Pull Request) 관련 DTO
- `DiscussionController` : Discussion 추가 API
- `DiscussionDto` : Req, Res DTO

### 수정 사항
- `Discussion` 엔티티 `LiveReviewAvailableTimes` 타입 변경 : Converter 이용해서 JSON <-> Object 매핑 ( 잘 되는지는 아직.. )
- `BaseResponseDto` camelCase로 변경

### 기타
- 현재는 `ThreadLocal` 이용해서 `Github` API 관련 객체 이용할 수 있게 했는데 다른 좋은 방법이 있을까요?
- Github Response IO Exception... 처리 방법