### PR TITLE
CAPS105~106: Discussion 생성 Service/Test 작성

### DIFF
--- a/src/main/java/com/hidiscuss/backend/config/JpaAuditingConfig.java
+++ b/src/main/java/com/hidiscuss/backend/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.hidiscuss.backend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/hidiscuss/backend/config/SwaggerConfig.java
+++ b/src/main/java/com/hidiscuss/backend/config/SwaggerConfig.java
@@ -14,7 +14,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 @Configuration
-@EnableWebMvc
 public class SwaggerConfig {
 
     private ApiInfo swaggerInfo() {

--- a/src/main/java/com/hidiscuss/backend/controller/DiscussionController.java
+++ b/src/main/java/com/hidiscuss/backend/controller/DiscussionController.java
@@ -2,7 +2,11 @@ package com.hidiscuss.backend.controller;
 
 import com.hidiscuss.backend.controller.dto.CreateDiscussionRequestDto;
 import com.hidiscuss.backend.controller.dto.DiscussionResponseDto;
+import com.hidiscuss.backend.entity.Discussion;
+import com.hidiscuss.backend.entity.User;
+import com.hidiscuss.backend.service.DiscussionService;
 import io.swagger.annotations.*;
+import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -10,12 +14,10 @@ import javax.validation.Valid;
 
 @RestController
 @RequestMapping("/discussion")
+@AllArgsConstructor
 public class DiscussionController {
-    //private final DiscussionService discussionService;
+    private final DiscussionService discussionService;
 
-    //public DiscussionController(DiscussionService discussionService) {
-    //    this.discussionService = discussionService;
-    //}
 
     @PostMapping("/")
     @ResponseStatus(HttpStatus.CREATED)
@@ -32,12 +34,24 @@ public class DiscussionController {
                 throw new IllegalArgumentException("코드가 없습니다.");
             }
         } else {
-            if (createDiscussionRequestDto.gitNodeId == null) {
-                throw new IllegalArgumentException("gitNodeId가 없습니다.");
+            if (createDiscussionRequestDto.gitNodeId == null || createDiscussionRequestDto.gitRepositoryId == null) {
+                throw new IllegalArgumentException("gitNodeId 또는 gitRepositoryId가 없습니다.");
             }
         }
-        return DiscussionResponseDto.fromEntity(CreateDiscussionRequestDto.toEntity(createDiscussionRequestDto));
-        //discussionService.createDiscussion(createDiscussionRequestDto);
+
+        if (createDiscussionRequestDto.liveReviewRequired) {
+            if (createDiscussionRequestDto.liveReviewAvailableTimes == null) {
+                throw new IllegalArgumentException("liveReviewAvailableTimes가 없습니다.");
+            }
+        }
+
+        if (createDiscussionRequestDto.usePriority) {
+            // rewardService.checkReward(createDiscussionRequestDto.rewardId) Transaction
+        }
+        // TODO : Inject the Authenticated User
+        User user = User.builder().id(9999L).build();
+        Discussion discussion = discussionService.create(createDiscussionRequestDto, user);
+        return DiscussionResponseDto.fromEntity(discussion);
     }
 }
 

--- a/src/main/java/com/hidiscuss/backend/controller/GithubController.java
+++ b/src/main/java/com/hidiscuss/backend/controller/GithubController.java
@@ -3,57 +3,45 @@ package com.hidiscuss.backend.controller;
 import com.hidiscuss.backend.controller.dto.GHCommitResponseDto;
 import com.hidiscuss.backend.controller.dto.GHPullRequestResponseDto;
 import com.hidiscuss.backend.controller.dto.GHRepositoryResponseDto;
+import com.hidiscuss.backend.service.GithubService;
 import com.hidiscuss.backend.utils.GithubContext;
+import lombok.AllArgsConstructor;
 import org.kohsuke.github.*;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/github")
+@AllArgsConstructor
 public class GithubController {
 
-    @GetMapping("/repos")
+    private final GithubService githubService;
+
+    @GetMapping("/repo")
     public List<GHRepositoryResponseDto> getRepo(
     //        @RequestAttribute("github") GitHub github
     ) {
-        GitHub github = GithubContext.getInstance();
-        try {
-            GHUser user = github.getUser("capstone-signal");
-            Map<String, GHRepository> repos = user.getRepositories();
-            return repos.values().stream().map(GHRepositoryResponseDto::fromGHRepository).collect(Collectors.toList());
-        } catch (Exception e) {
-            throw new RuntimeException(e); // TODO : custom exception
-        }
+        Collection<GHRepository> repos = githubService.getRepositories();
+        return repos.stream().map(GHRepositoryResponseDto::fromGHRepository).collect(Collectors.toList());
     }
 
-    @GetMapping("/commits/{repoId}")
+    @GetMapping("repo/{repoId}/commit")
     public List<GHCommitResponseDto> getCommits(
             @PathVariable("repoId") Long repoId
     ) {
-        GitHub github = GithubContext.getInstance();
-        try {
-            GHRepository repo = github.getRepositoryById(repoId);
-            List<GHCommit> commits = repo.listCommits().toList();
-            return commits.stream().map(GHCommitResponseDto::fromGHCommit).collect(Collectors.toList());
-        } catch (Exception e) {
-            throw new RuntimeException(e); // TODO : custom exception
-        }
+        Collection<GHCommit> commits = githubService.getCommitsByRepoId(repoId);
+        return commits.stream().map(GHCommitResponseDto::fromGHCommit).collect(Collectors.toList());
     }
 
-    @GetMapping("/prs/{repoId}")
+    @GetMapping("/repo/{repoId}/pr")
     public List<GHPullRequestResponseDto> getPullRequests(
             @PathVariable("repoId") Long repoId
     ) {
-        GitHub github = GithubContext.getInstance();
-        try {
-            GHRepository repo = github.getRepositoryById(repoId);
-            List<GHPullRequest> pullRequests = repo.queryPullRequests().list().toList();
-            return pullRequests.stream().map(GHPullRequestResponseDto::fromGHPullRequest).collect(Collectors.toList());
-        } catch (Exception e) {
-            throw new RuntimeException(e); // TODO : custom exception
-        }
+        Collection<GHPullRequest> pullRequests = githubService.getPullRequestsByRepoId(repoId);
+        return pullRequests.stream().map(GHPullRequestResponseDto::fromGHPullRequest).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/hidiscuss/backend/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/hidiscuss/backend/controller/GlobalExceptionHandler.java
@@ -1,13 +1,14 @@
 package com.hidiscuss.backend.controller;
 
+import com.hidiscuss.backend.exception.GithubException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.client.HttpClientErrorException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -17,13 +18,21 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public String handleException(MethodArgumentNotValidException e) {
         logger.warn(e.getMessage());
-        return e.getBindingResult().getFieldError().getDefaultMessage(); // TODO : return proper error message
+        ObjectError error = e.getBindingResult().getAllErrors().get(0);
+        return error.getDefaultMessage();
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public String handleException(IllegalArgumentException e) {
         logger.warn(e.getMessage());
+        return e.getMessage();
+    }
+
+    @ExceptionHandler(GithubException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String handleException(GithubException e) {
+        logger.error(e.getMessage());
         return e.getMessage();
     }
 

--- a/src/main/java/com/hidiscuss/backend/controller/dto/CreateDiscussionRequestDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/CreateDiscussionRequestDto.java
@@ -3,6 +3,7 @@ package com.hidiscuss.backend.controller.dto;
 import com.hidiscuss.backend.entity.Discussion;
 import com.hidiscuss.backend.entity.DiscussionState;
 import com.hidiscuss.backend.entity.LiveReviewAvailableTimes;
+import com.hidiscuss.backend.entity.User;
 import org.springframework.lang.Nullable;
 
 import javax.validation.constraints.NotNull;
@@ -38,9 +39,10 @@ public class CreateDiscussionRequestDto {
     @Nullable
     public List<CreateDiscussionCodeRequestDto> codes;
 
-    public static Discussion toEntity(CreateDiscussionRequestDto dto) {
+    public static Discussion toEntity(CreateDiscussionRequestDto dto, User user) {
         return Discussion.builder()
                 .question(dto.question)
+                .user(user)
                 .liveReviewRequired(dto.liveReviewRequired)
                 .liveReviewAvailableTimes(dto.liveReviewAvailableTimes)
                 .priority(dto.usePriority ? 255L : 0L)

--- a/src/main/java/com/hidiscuss/backend/controller/dto/CreateDiscussionRequestDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/CreateDiscussionRequestDto.java
@@ -46,7 +46,6 @@ public class CreateDiscussionRequestDto {
                 .liveReviewRequired(dto.liveReviewRequired)
                 .liveReviewAvailableTimes(dto.liveReviewAvailableTimes)
                 .priority(dto.usePriority ? 255L : 0L)
-                .state(DiscussionState.NOT_REVIEWED)
                 .build();
     }
 

--- a/src/main/java/com/hidiscuss/backend/controller/dto/CreateDiscussionRequestDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/CreateDiscussionRequestDto.java
@@ -26,7 +26,7 @@ public class CreateDiscussionRequestDto {
     @Nullable
     public String gitNodeId;
 
-    @NotNull
+    @Nullable
     public LiveReviewAvailableTimes liveReviewAvailableTimes;
 
     @Nullable

--- a/src/main/java/com/hidiscuss/backend/controller/dto/GHPullRequestResponseDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/GHPullRequestResponseDto.java
@@ -18,7 +18,7 @@ public class GHPullRequestResponseDto {
     }
     public static GHPullRequestResponseDto fromGHPullRequest(GHPullRequest pullRequest) {
         return new GHPullRequestResponseDto(
-                pullRequest.getId(),
+                (long) pullRequest.getNumber(), // ;pullRequest.getId(), memo: getId() return globally unique id
                 pullRequest.getTitle(),
                 pullRequest.getHtmlUrl().toString()
         );

--- a/src/main/java/com/hidiscuss/backend/controller/dto/UserResponseDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/UserResponseDto.java
@@ -1,0 +1,4 @@
+package com.hidiscuss.backend.controller.dto;
+
+public class UserResponseDto {
+}

--- a/src/main/java/com/hidiscuss/backend/controller/exception/BaseApiException.java
+++ b/src/main/java/com/hidiscuss/backend/controller/exception/BaseApiException.java
@@ -1,5 +1,0 @@
-package com.hidiscuss.backend.controller.exception;
-
-public class BaseApiException extends Exception {
-
-}

--- a/src/main/java/com/hidiscuss/backend/entity/Discussion.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Discussion.java
@@ -47,4 +47,8 @@ public class Discussion extends BaseEntity {
         this.liveReviewAvailableTimes = liveReviewAvailableTimes;
         this.priority = priority;
     }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
 }

--- a/src/main/java/com/hidiscuss/backend/entity/Discussion.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Discussion.java
@@ -38,9 +38,8 @@ public class Discussion extends BaseEntity {
     private Long priority;
 
     @Builder
-    public Discussion(Long id, DiscussionState state, User user, String question, Boolean liveReviewRequired, LiveReviewAvailableTimes liveReviewAvailableTimes, Long priority) {
-        this.id = id;
-        this.state = state;
+    public Discussion(User user, String question, Boolean liveReviewRequired, LiveReviewAvailableTimes liveReviewAvailableTimes, Long priority) {
+        this.state = DiscussionState.NOT_REVIEWED;
         this.user = user;
         this.question = question;
         this.liveReviewRequired = liveReviewRequired;

--- a/src/main/java/com/hidiscuss/backend/entity/DiscussionCode.java
+++ b/src/main/java/com/hidiscuss/backend/entity/DiscussionCode.java
@@ -43,8 +43,7 @@ public class DiscussionCode extends BaseEntity {
     private String content;
 
     @Builder
-    public DiscussionCode(Long id, Discussion discussion, String sha, String filename, Status status, Long additions, Long deletions, Long changes, String content) {
-        this.id = id;
+    public DiscussionCode(Discussion discussion, String sha, String filename, Status status, Long additions, Long deletions, Long changes, String content) {
         this.discussion = discussion;
         this.sha = sha;
         this.filename = filename;

--- a/src/main/java/com/hidiscuss/backend/entity/Status.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Status.java
@@ -11,14 +11,12 @@ public enum Status {
 
     public static Status convertFromGithubStatus(String status) {
         switch (status) {
-            case "added":
-                return ADDED;
             case "modified":
                 return MODIFIED;
             case "removed":
                 return REMOVED;
-            default:
-                return null;
+            default: // "added" or other
+                return ADDED;
         }
     }
 

--- a/src/main/java/com/hidiscuss/backend/entity/Status.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Status.java
@@ -9,6 +9,19 @@ public enum Status {
         this.id = id;
     }
 
+    public static Status convertFromGithubStatus(String status) {
+        switch (status) {
+            case "added":
+                return ADDED;
+            case "modified":
+                return MODIFIED;
+            case "removed":
+                return REMOVED;
+            default:
+                return null;
+        }
+    }
+
     public int getId() {
         return id;
     }

--- a/src/main/java/com/hidiscuss/backend/exception/BaseApiException.java
+++ b/src/main/java/com/hidiscuss/backend/exception/BaseApiException.java
@@ -1,0 +1,9 @@
+package com.hidiscuss.backend.exception;
+
+public class BaseApiException extends Exception {
+    private String message;
+
+    public BaseApiException(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/exception/EmptyDiscussionCodeException.java
+++ b/src/main/java/com/hidiscuss/backend/exception/EmptyDiscussionCodeException.java
@@ -1,0 +1,14 @@
+package com.hidiscuss.backend.exception;
+
+public class EmptyDiscussionCodeException extends RuntimeException {
+    private String message;
+
+    public EmptyDiscussionCodeException(String message) {
+        super(message);
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/exception/GithubException.java
+++ b/src/main/java/com/hidiscuss/backend/exception/GithubException.java
@@ -1,0 +1,19 @@
+package com.hidiscuss.backend.exception;
+
+public class GithubException extends RuntimeException {
+    private String message;
+
+    public GithubException(String message) {
+        super(message);
+        this.message = message;
+    }
+
+    public GithubException(String message, Throwable cause) {
+        super(message, cause);
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/service/DiscussionCodeService.java
+++ b/src/main/java/com/hidiscuss/backend/service/DiscussionCodeService.java
@@ -7,13 +7,16 @@ import com.hidiscuss.backend.entity.Status;
 import com.hidiscuss.backend.repository.DiscussionCodeRepository;
 import lombok.AllArgsConstructor;
 import org.kohsuke.github.GHCommit;
+import org.kohsuke.github.GHPullRequest;
 import org.springframework.stereotype.Service;
 
+import javax.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 
 @Service
 @AllArgsConstructor
+@Transactional
 public class DiscussionCodeService {
     private final DiscussionCodeRepository discussionCodeRepository;
 
@@ -38,20 +41,44 @@ public class DiscussionCodeService {
     public List<DiscussionCode> createFromCommit(Discussion discussion, GHCommit commit, List<GHCommit.File> files) {
         List<DiscussionCode> codes = new ArrayList<>();
         files.forEach(f -> {
+            if (f.getPatch() == null) {
+                return;
+            }
             DiscussionCode code = DiscussionCode.builder()
                     .discussion(discussion)
                     .filename(f.getFileName())
-                    .content(f.getPatch())
+                    .content(f.getPatch()) // CONTENT TODO : 이거 어떻게 가져오는지 확인해보기
                     .sha(f.getSha())
                     .status(Status.convertFromGithubStatus(f.getStatus()))
                     .additions((long) f.getLinesAdded())
                     .deletions((long) f.getLinesDeleted())
                     .changes((long) f.getLinesChanged())
                     .build();
+            codes.add(code);
         });
         return discussionCodeRepository.saveAll(codes); // TEST TODO : bulk save
     }
 
 
+    public List<DiscussionCode> createFromPR(Discussion discussion, GHPullRequest pr) {
+        List<DiscussionCode> codes = new ArrayList<>();
+        pr.listFiles().forEach(f -> {
+            if (f.getPatch() == null) {
+                return;
+            }
+            DiscussionCode code = DiscussionCode.builder()
+                    .discussion(discussion)
+                    .filename(f.getFilename())
+                    .content(f.getPatch())
+                    .sha(f.getSha())
+                    .status(Status.convertFromGithubStatus(f.getStatus()))
+                    .additions((long) f.getAdditions())
+                    .deletions((long) f.getDeletions())
+                    .changes((long) f.getChanges())
+                    .build();
+            codes.add(code);
+        });
+        return discussionCodeRepository.saveAll(codes); // TEST TODO : bulk save
+    }
 }
 

--- a/src/main/java/com/hidiscuss/backend/service/DiscussionCodeService.java
+++ b/src/main/java/com/hidiscuss/backend/service/DiscussionCodeService.java
@@ -4,10 +4,12 @@ import com.hidiscuss.backend.controller.dto.CreateDiscussionCodeRequestDto;
 import com.hidiscuss.backend.entity.Discussion;
 import com.hidiscuss.backend.entity.DiscussionCode;
 import com.hidiscuss.backend.entity.Status;
+import com.hidiscuss.backend.exception.EmptyDiscussionCodeException;
 import com.hidiscuss.backend.repository.DiscussionCodeRepository;
 import lombok.AllArgsConstructor;
 import org.kohsuke.github.GHCommit;
 import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHPullRequestFileDetail;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
@@ -35,10 +37,13 @@ public class DiscussionCodeService {
                     .build();
             codes.add(code);
         });
+        if (codes.size() == 0) {
+           throw new EmptyDiscussionCodeException("No codes found");
+        }
         return discussionCodeRepository.saveAll(codes); // TEST TODO : bulk save
     }
 
-    public List<DiscussionCode> createFromCommit(Discussion discussion, GHCommit commit, List<GHCommit.File> files) {
+    public List<DiscussionCode> createFromCommit(Discussion discussion, List<GHCommit.File> files) {
         List<DiscussionCode> codes = new ArrayList<>();
         files.forEach(f -> {
             if (f.getPatch() == null) {
@@ -56,13 +61,16 @@ public class DiscussionCodeService {
                     .build();
             codes.add(code);
         });
+        if (codes.size() == 0) {
+            throw new EmptyDiscussionCodeException("No codes found");
+        }
         return discussionCodeRepository.saveAll(codes); // TEST TODO : bulk save
     }
 
 
-    public List<DiscussionCode> createFromPR(Discussion discussion, GHPullRequest pr) {
+    public List<DiscussionCode> createFromPR(Discussion discussion, List<GHPullRequestFileDetail> files) {
         List<DiscussionCode> codes = new ArrayList<>();
-        pr.listFiles().forEach(f -> {
+        files.forEach(f -> {
             if (f.getPatch() == null) {
                 return;
             }
@@ -78,6 +86,9 @@ public class DiscussionCodeService {
                     .build();
             codes.add(code);
         });
+        if (codes.size() == 0) {
+            throw new EmptyDiscussionCodeException("No codes found");
+        }
         return discussionCodeRepository.saveAll(codes); // TEST TODO : bulk save
     }
 }

--- a/src/main/java/com/hidiscuss/backend/service/DiscussionCodeService.java
+++ b/src/main/java/com/hidiscuss/backend/service/DiscussionCodeService.java
@@ -1,0 +1,57 @@
+package com.hidiscuss.backend.service;
+
+import com.hidiscuss.backend.controller.dto.CreateDiscussionCodeRequestDto;
+import com.hidiscuss.backend.entity.Discussion;
+import com.hidiscuss.backend.entity.DiscussionCode;
+import com.hidiscuss.backend.entity.Status;
+import com.hidiscuss.backend.repository.DiscussionCodeRepository;
+import lombok.AllArgsConstructor;
+import org.kohsuke.github.GHCommit;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@AllArgsConstructor
+public class DiscussionCodeService {
+    private final DiscussionCodeRepository discussionCodeRepository;
+
+    public List<DiscussionCode> createFromDirect(Discussion discussion, List<CreateDiscussionCodeRequestDto> dto) {
+        List<DiscussionCode> codes = new ArrayList<>();
+        dto.forEach(d -> {
+            DiscussionCode code = DiscussionCode.builder()
+                    .discussion(discussion)
+                    .filename(d.filename)
+                    .content(d.content)
+                    .sha("DIRECT")
+                    .status(Status.ADDED)
+                    .additions((long) d.getLength())
+                    .deletions(0L)
+                    .changes(0L)
+                    .build();
+            codes.add(code);
+        });
+        return discussionCodeRepository.saveAll(codes); // TEST TODO : bulk save
+    }
+
+    public List<DiscussionCode> createFromCommit(Discussion discussion, GHCommit commit, List<GHCommit.File> files) {
+        List<DiscussionCode> codes = new ArrayList<>();
+        files.forEach(f -> {
+            DiscussionCode code = DiscussionCode.builder()
+                    .discussion(discussion)
+                    .filename(f.getFileName())
+                    .content(f.getPatch())
+                    .sha(f.getSha())
+                    .status(Status.convertFromGithubStatus(f.getStatus()))
+                    .additions((long) f.getLinesAdded())
+                    .deletions((long) f.getLinesDeleted())
+                    .changes((long) f.getLinesChanged())
+                    .build();
+        });
+        return discussionCodeRepository.saveAll(codes); // TEST TODO : bulk save
+    }
+
+
+}
+

--- a/src/main/java/com/hidiscuss/backend/service/DiscussionService.java
+++ b/src/main/java/com/hidiscuss/backend/service/DiscussionService.java
@@ -2,16 +2,16 @@ package com.hidiscuss.backend.service;
 
 import com.hidiscuss.backend.controller.dto.CreateDiscussionRequestDto;
 import com.hidiscuss.backend.entity.Discussion;
-import com.hidiscuss.backend.entity.DiscussionCode;
-import com.hidiscuss.backend.entity.DiscussionTag;
 import com.hidiscuss.backend.entity.User;
 import com.hidiscuss.backend.repository.DiscussionRepository;
 import lombok.AllArgsConstructor;
 import org.kohsuke.github.GHCommit;
 import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHPullRequestFileDetail;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import javax.validation.constraints.NotNull;
 import java.util.List;
 
 @Service
@@ -25,39 +25,29 @@ public class DiscussionService {
 
     public Discussion create(
             CreateDiscussionRequestDto dto,
-            User user // TODO: user type
+            @NotNull User user // TODO: user type
     ) {
-        Discussion discussion = CreateDiscussionRequestDto.toEntity(dto);
-        discussion.setUser(user);
+        Discussion discussion = CreateDiscussionRequestDto.toEntity(dto, user);
         discussion = discussionRepository.save(discussion);
 
         // Processing Tag
         discussionTagService.create(discussion, dto.tagIds);
         // Processing DiscussionCode
-        List<DiscussionCode> discussionCodes;
         switch(dto.discussionType) { // case가 PR or COMMIT이면 Controller에서 검증
             case "PR":
                 GHPullRequest pr = githubService.getPullRequestById(Long.parseLong(dto.gitRepositoryId), Integer.parseInt(dto.gitNodeId));
-                discussionCodes = discussionCodeService.createFromPR(discussion, pr);
+                List<GHPullRequestFileDetail> prFiles = githubService.getFilesByPullRequest(pr);
+                discussionCodeService.createFromPR(discussion, prFiles);
                 break;
             case "COMMIT":
-                System.out.println("COMMIT");
                 GHCommit commit = githubService.getCommitById(Long.parseLong(dto.gitRepositoryId), dto.gitNodeId);
-                List<GHCommit.File> files = githubService.getFilesByCommit(commit);
-                discussionCodes = discussionCodeService.createFromCommit(discussion, commit, files);
+                List<GHCommit.File> commitFiles = githubService.getFilesByCommit(commit);
+                discussionCodeService.createFromCommit(discussion, commitFiles);
                 break;
             case "DIRECT":
-                discussionCodes = discussionCodeService.createFromDirect(discussion, dto.codes);
+                discussionCodeService.createFromDirect(discussion, dto.codes);
                 break;
         }
         return discussion;
     }
-/*
-    public Discussion create(Discussion discussion, List<DiscussionCode> discussionCodes) {
-        Discussion savedDiscussion = discussionRepository.save(discussion);
-        List<DiscussionCode> savedDiscussionCodes = discussionCodeService.create(discussionCodes, savedDiscussion);
-
-    }
-
- */
 }

--- a/src/main/java/com/hidiscuss/backend/service/DiscussionService.java
+++ b/src/main/java/com/hidiscuss/backend/service/DiscussionService.java
@@ -1,0 +1,61 @@
+package com.hidiscuss.backend.service;
+
+import com.hidiscuss.backend.controller.dto.CreateDiscussionRequestDto;
+import com.hidiscuss.backend.entity.Discussion;
+import com.hidiscuss.backend.entity.DiscussionCode;
+import com.hidiscuss.backend.entity.DiscussionTag;
+import com.hidiscuss.backend.entity.User;
+import com.hidiscuss.backend.repository.DiscussionRepository;
+import lombok.AllArgsConstructor;
+import org.kohsuke.github.GHCommit;
+import org.kohsuke.github.GHPullRequest;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+@Service
+@AllArgsConstructor
+@Transactional
+public class DiscussionService {
+    private final DiscussionRepository discussionRepository;
+    private final GithubService githubService;
+    private final DiscussionCodeService discussionCodeService;
+    private final DiscussionTagService discussionTagService;
+
+    public Discussion create(
+            CreateDiscussionRequestDto dto,
+            User user // TODO: user type
+    ) {
+        Discussion discussion = CreateDiscussionRequestDto.toEntity(dto);
+        discussion.setUser(user);
+        discussion = discussionRepository.save(discussion);
+
+        // Processing Tag
+        discussionTagService.create(discussion, dto.tagIds);
+        // Processing DiscussionCode
+        List<DiscussionCode> discussionCodes;
+        switch(dto.discussionType) { // case가 PR or COMMIT이면 Controller에서 검증
+            case "PR":
+                GHPullRequest pr = githubService.getPullRequestById(Long.parseLong(dto.gitRepositoryId), Integer.parseInt(dto.gitNodeId));
+                //discussionCodes = discussionCodeService.createFromPR(discussion, pr);
+                break;
+            case "COMMIT":
+                GHCommit commit = githubService.getCommitById(Long.parseLong(dto.gitRepositoryId), dto.gitNodeId);
+                discussionCodes = discussionCodeService.createFromCommit(discussion, commit, null);
+                break;
+            case "DIRECT":
+                discussionCodes = discussionCodeService.createFromDirect(discussion, dto.codes);
+                break;
+        }
+        return discussion;
+    }
+/*
+    public Discussion create(Discussion discussion, List<DiscussionCode> discussionCodes) {
+        Discussion savedDiscussion = discussionRepository.save(discussion);
+        List<DiscussionCode> savedDiscussionCodes = discussionCodeService.create(discussionCodes, savedDiscussion);
+
+    }
+
+ */
+}

--- a/src/main/java/com/hidiscuss/backend/service/DiscussionService.java
+++ b/src/main/java/com/hidiscuss/backend/service/DiscussionService.java
@@ -37,12 +37,12 @@ public class DiscussionService {
             case "PR":
                 GHPullRequest pr = githubService.getPullRequestById(Long.parseLong(dto.gitRepositoryId), Integer.parseInt(dto.gitNodeId));
                 List<GHPullRequestFileDetail> prFiles = githubService.getFilesByPullRequest(pr);
-                discussionCodeService.createFromPR(discussion, prFiles);
+                discussionCodeService.createFromFiles(discussion, prFiles);
                 break;
             case "COMMIT":
                 GHCommit commit = githubService.getCommitById(Long.parseLong(dto.gitRepositoryId), dto.gitNodeId);
                 List<GHCommit.File> commitFiles = githubService.getFilesByCommit(commit);
-                discussionCodeService.createFromCommit(discussion, commitFiles);
+                discussionCodeService.createFromFiles(discussion, commitFiles);
                 break;
             case "DIRECT":
                 discussionCodeService.createFromDirect(discussion, dto.codes);

--- a/src/main/java/com/hidiscuss/backend/service/DiscussionService.java
+++ b/src/main/java/com/hidiscuss/backend/service/DiscussionService.java
@@ -38,11 +38,13 @@ public class DiscussionService {
         switch(dto.discussionType) { // case가 PR or COMMIT이면 Controller에서 검증
             case "PR":
                 GHPullRequest pr = githubService.getPullRequestById(Long.parseLong(dto.gitRepositoryId), Integer.parseInt(dto.gitNodeId));
-                //discussionCodes = discussionCodeService.createFromPR(discussion, pr);
+                discussionCodes = discussionCodeService.createFromPR(discussion, pr);
                 break;
             case "COMMIT":
+                System.out.println("COMMIT");
                 GHCommit commit = githubService.getCommitById(Long.parseLong(dto.gitRepositoryId), dto.gitNodeId);
-                discussionCodes = discussionCodeService.createFromCommit(discussion, commit, null);
+                List<GHCommit.File> files = githubService.getFilesByCommit(commit);
+                discussionCodes = discussionCodeService.createFromCommit(discussion, commit, files);
                 break;
             case "DIRECT":
                 discussionCodes = discussionCodeService.createFromDirect(discussion, dto.codes);

--- a/src/main/java/com/hidiscuss/backend/service/DiscussionTagService.java
+++ b/src/main/java/com/hidiscuss/backend/service/DiscussionTagService.java
@@ -1,0 +1,30 @@
+package com.hidiscuss.backend.service;
+
+import com.hidiscuss.backend.entity.Discussion;
+import com.hidiscuss.backend.entity.DiscussionTag;
+import com.hidiscuss.backend.entity.Tag;
+import com.hidiscuss.backend.repository.DiscussionTagRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional
+@AllArgsConstructor
+public class DiscussionTagService {
+    private final DiscussionTagRepository discussionTagRepository;
+    public List<DiscussionTag> create(Discussion discussion, List<Long> tagIds) {
+        List<DiscussionTag> discussionTags = new ArrayList<>();
+        tagIds.forEach(tagId -> {
+            DiscussionTag discussionTag = DiscussionTag.builder()
+                    .discussion(discussion)
+                    .tag(Tag.builder().id(tagId).build()) // no validation..
+                    .build();
+            discussionTags.add(discussionTag);
+        });
+        return discussionTagRepository.saveAll(discussionTags);
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/service/GithubService.java
+++ b/src/main/java/com/hidiscuss/backend/service/GithubService.java
@@ -1,5 +1,6 @@
 package com.hidiscuss.backend.service;
 
+import com.hidiscuss.backend.exception.GithubException;
 import com.hidiscuss.backend.utils.GithubContext;
 import org.kohsuke.github.*;
 import org.springframework.stereotype.Service;
@@ -19,8 +20,7 @@ public class GithubService {
         try {
             return getGitHub().getUser("capstone-signal").getRepositories().values(); // TODO : get user from session
         } catch (IOException e) {
-            e.printStackTrace();
-            throw new RuntimeException(e);
+            throw new GithubException("Failed to get repositories", e);
         }
     }
 
@@ -28,8 +28,7 @@ public class GithubService {
         try {
             return getGitHub().getRepositoryById(repoId).listCommits().toList();
         } catch (IOException e) {
-            e.printStackTrace();
-            throw new RuntimeException(e);
+            throw new GithubException("Failed to get commits", e);
         }
     }
 
@@ -37,8 +36,7 @@ public class GithubService {
         try {
             return getGitHub().getRepositoryById(repoId).queryPullRequests().state(GHIssueState.ALL).list().toList();
         } catch (IOException e) {
-            e.printStackTrace();
-            throw new RuntimeException(e);
+            throw new GithubException("Failed to get pull requests", e);
         }
     }
 
@@ -46,8 +44,7 @@ public class GithubService {
         try {
             return getGitHub().getRepositoryById(repoId).getPullRequest(pullRequestId);
         } catch (IOException e) {
-            e.printStackTrace();
-            throw new RuntimeException(e);
+            throw new GithubException("Failed to get pull request", e);
         }
     }
 
@@ -55,8 +52,7 @@ public class GithubService {
         try {
             return getGitHub().getRepositoryById(repoId).getCommit(sha);
         } catch (IOException e) {
-            e.printStackTrace();
-            throw new RuntimeException(e);
+            throw new GithubException("Failed to get commit", e);
         }
     }
 
@@ -64,8 +60,15 @@ public class GithubService {
         try {
             return commit.getFiles();
         } catch (IOException e) {
-            e.printStackTrace();
-            throw new RuntimeException(e);
+            throw new GithubException("Failed to get files", e);
+        }
+    }
+
+    public List<GHPullRequestFileDetail> getFilesByPullRequest(GHPullRequest pr) {
+        try {
+            return pr.listFiles().toList();
+        } catch (IOException e) {
+            throw new GithubException("Failed to get files", e);
         }
     }
 }

--- a/src/main/java/com/hidiscuss/backend/service/GithubService.java
+++ b/src/main/java/com/hidiscuss/backend/service/GithubService.java
@@ -1,0 +1,61 @@
+package com.hidiscuss.backend.service;
+
+import com.hidiscuss.backend.utils.GithubContext;
+import org.kohsuke.github.*;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.Collection;
+
+@Service
+public class GithubService {
+
+    private GitHub getGitHub() {
+        return GithubContext.getInstance();
+    }
+
+    public Collection<GHRepository> getRepositories() {
+        try {
+            return getGitHub().getUser("capstone-signal").getRepositories().values(); // TODO : get user from session
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Collection<GHCommit> getCommitsByRepoId(Long repoId) {
+        try {
+            return getGitHub().getRepositoryById(repoId).listCommits().toList();
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Collection<GHPullRequest> getPullRequestsByRepoId(Long repoId) {
+        try {
+            return getGitHub().getRepositoryById(repoId).queryPullRequests().state(GHIssueState.ALL).list().toList();
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+    }
+
+    public GHPullRequest getPullRequestById(Long repoId, int pullRequestId) {
+        try {
+            return getGitHub().getRepositoryById(repoId).getPullRequest(pullRequestId);
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+    }
+
+    public GHCommit getCommitById(Long repoId, String sha) {
+        try {
+            return getGitHub().getRepositoryById(repoId).getCommit(sha);
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/service/GithubService.java
+++ b/src/main/java/com/hidiscuss/backend/service/GithubService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.List;
 
 @Service
 public class GithubService {
@@ -53,6 +54,15 @@ public class GithubService {
     public GHCommit getCommitById(Long repoId, String sha) {
         try {
             return getGitHub().getRepositoryById(repoId).getCommit(sha);
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+    }
+
+    public List<GHCommit.File> getFilesByCommit(GHCommit commit) {
+        try {
+            return commit.getFiles();
         } catch (IOException e) {
             e.printStackTrace();
             throw new RuntimeException(e);

--- a/src/main/resources/config/db/application.yml
+++ b/src/main/resources/config/db/application.yml
@@ -4,10 +4,10 @@ spring:
     url: jdbc:mysql://localhost:3306/hidiscuss?autoReconnect=true
     hikari:
       username: root
-      password: 17181718
+      password: root
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-     # ddl-auto: none
+      # ddl-auto: none
       ddl-auto: create
     generate-ddl: true

--- a/src/main/resources/config/mvc/application.yml
+++ b/src/main/resources/config/mvc/application.yml
@@ -1,0 +1,4 @@
+spring:
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher

--- a/src/test/java/com/hidiscuss/backend/service/DiscussionCodeServiceTest.java
+++ b/src/test/java/com/hidiscuss/backend/service/DiscussionCodeServiceTest.java
@@ -55,19 +55,20 @@ public class DiscussionCodeServiceTest {
     }
 
     @Test
-    public void createFromCommit_withNoPatch() {
+    public void createFromFiles_withNoPatchFile() {
         List<GHCommit.File> files = new ArrayList<>();
         GHCommit.File file = Mockito.mock(GHCommit.File.class);
         when(file.getPatch()).thenReturn(null);
+        when(file.getStatus()).thenReturn("added");
         files.add(file);
 
-        Exception ex = assertThrows(EmptyDiscussionCodeException.class, () -> discussionCodeService.createFromCommit(discussion, files));
+        Exception ex = assertThrows(EmptyDiscussionCodeException.class, () -> discussionCodeService.createFromFiles(discussion, files));
 
         assertThat(ex).isNotNull();
     }
 
     @Test
-    public void createFromCommit() {
+    public void createFromFiles() {
         List<GHCommit.File> files = new ArrayList<>();
         GHCommit.File file = Mockito.mock(GHCommit.File.class);
         when(file.getFileName()).thenReturn("test.java");
@@ -75,35 +76,7 @@ public class DiscussionCodeServiceTest {
         when(file.getStatus()).thenReturn("added");
         files.add(file);
 
-        List<DiscussionCode> discussionCodes = discussionCodeService.createFromCommit(discussion, files);
-
-        assertThat(discussionCodes).isNotNull();
-        assertThat(discussionCodes.size()).isEqualTo(files.size());
-    }
-
-    @Test
-    public void createFromPR_withNoPatch() {
-        GHPullRequest pr = Mockito.mock(GHPullRequest.class);
-        GHPullRequestFileDetail file = Mockito.mock(GHPullRequestFileDetail.class);
-        List<GHPullRequestFileDetail> files = List.of(file);
-
-
-        Exception ex = assertThrows(EmptyDiscussionCodeException.class, () -> discussionCodeService.createFromPR(discussion, files));
-
-        assertThat(ex).isNotNull();
-    }
-
-    @Test
-    public void createFromPullRequest() {
-        GHPullRequest pr = Mockito.mock(GHPullRequest.class);
-        GHPullRequestFileDetail file = Mockito.mock(GHPullRequestFileDetail.class);
-        List<GHPullRequestFileDetail> files = List.of(file);
-        when(file.getFilename()).thenReturn("test.java");
-        when(file.getPatch()).thenReturn("test");
-        when(file.getStatus()).thenReturn("added");
-
-
-        List<DiscussionCode> discussionCodes = discussionCodeService.createFromPR(discussion, files);
+        List<DiscussionCode> discussionCodes = discussionCodeService.createFromFiles(discussion, files);
 
         assertThat(discussionCodes).isNotNull();
         assertThat(discussionCodes.size()).isEqualTo(files.size());

--- a/src/test/java/com/hidiscuss/backend/service/DiscussionCodeServiceTest.java
+++ b/src/test/java/com/hidiscuss/backend/service/DiscussionCodeServiceTest.java
@@ -1,0 +1,118 @@
+package com.hidiscuss.backend.service;
+
+import com.hidiscuss.backend.controller.dto.CreateDiscussionCodeRequestDto;
+import com.hidiscuss.backend.entity.Discussion;
+import com.hidiscuss.backend.entity.DiscussionCode;
+import com.hidiscuss.backend.exception.EmptyDiscussionCodeException;
+import com.hidiscuss.backend.repository.DiscussionCodeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kohsuke.github.*;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class DiscussionCodeServiceTest {
+    @Mock
+    private DiscussionCodeRepository discussionCodeRepository;
+
+    @InjectMocks
+    private DiscussionCodeService discussionCodeService;
+
+    private Discussion discussion = null;
+    @Test
+    public void isDefined() {
+        assertThat(discussionCodeService).isNotNull();
+    }
+
+    @BeforeEach
+    void setUp() {
+        Mockito.lenient().when(discussionCodeRepository.saveAll(Mockito.any())).thenAnswer(i -> i.getArgument(0));
+        discussion = new Discussion();
+    }
+
+    @Test
+    public void createFromDirectTest() {
+           List<CreateDiscussionCodeRequestDto> createDiscussionCodeRequestDtos = List.of(
+                   getCreateDiscussionCodeRequestDto(),
+                   getCreateDiscussionCodeRequestDto()
+           );
+
+           List<DiscussionCode> discussionCodes = discussionCodeService.createFromDirect(discussion, createDiscussionCodeRequestDtos);
+
+           assertThat(discussionCodes).isNotNull();
+           assertThat(discussionCodes.size()).isEqualTo(createDiscussionCodeRequestDtos.size());
+    }
+
+    @Test
+    public void createFromCommit_withNoPatch() {
+        List<GHCommit.File> files = new ArrayList<>();
+        GHCommit.File file = Mockito.mock(GHCommit.File.class);
+        when(file.getPatch()).thenReturn(null);
+        files.add(file);
+
+        Exception ex = assertThrows(EmptyDiscussionCodeException.class, () -> discussionCodeService.createFromCommit(discussion, files));
+
+        assertThat(ex).isNotNull();
+    }
+
+    @Test
+    public void createFromCommit() {
+        List<GHCommit.File> files = new ArrayList<>();
+        GHCommit.File file = Mockito.mock(GHCommit.File.class);
+        when(file.getFileName()).thenReturn("test.java");
+        when(file.getPatch()).thenReturn("test");
+        when(file.getStatus()).thenReturn("added");
+        files.add(file);
+
+        List<DiscussionCode> discussionCodes = discussionCodeService.createFromCommit(discussion, files);
+
+        assertThat(discussionCodes).isNotNull();
+        assertThat(discussionCodes.size()).isEqualTo(files.size());
+    }
+
+    @Test
+    public void createFromPR_withNoPatch() {
+        GHPullRequest pr = Mockito.mock(GHPullRequest.class);
+        GHPullRequestFileDetail file = Mockito.mock(GHPullRequestFileDetail.class);
+        List<GHPullRequestFileDetail> files = List.of(file);
+
+
+        Exception ex = assertThrows(EmptyDiscussionCodeException.class, () -> discussionCodeService.createFromPR(discussion, files));
+
+        assertThat(ex).isNotNull();
+    }
+
+    @Test
+    public void createFromPullRequest() {
+        GHPullRequest pr = Mockito.mock(GHPullRequest.class);
+        GHPullRequestFileDetail file = Mockito.mock(GHPullRequestFileDetail.class);
+        List<GHPullRequestFileDetail> files = List.of(file);
+        when(file.getFilename()).thenReturn("test.java");
+        when(file.getPatch()).thenReturn("test");
+        when(file.getStatus()).thenReturn("added");
+
+
+        List<DiscussionCode> discussionCodes = discussionCodeService.createFromPR(discussion, files);
+
+        assertThat(discussionCodes).isNotNull();
+        assertThat(discussionCodes.size()).isEqualTo(files.size());
+    }
+
+    private CreateDiscussionCodeRequestDto getCreateDiscussionCodeRequestDto() {
+        CreateDiscussionCodeRequestDto createDiscussionCodeRequestDto = new CreateDiscussionCodeRequestDto();
+        createDiscussionCodeRequestDto.filename = "filename";
+        createDiscussionCodeRequestDto.content = "code";
+        return createDiscussionCodeRequestDto;
+    }
+}

--- a/src/test/java/com/hidiscuss/backend/service/DiscussionServiceTest.java
+++ b/src/test/java/com/hidiscuss/backend/service/DiscussionServiceTest.java
@@ -1,0 +1,107 @@
+package com.hidiscuss.backend.service;
+
+import com.hidiscuss.backend.controller.dto.CreateDiscussionCodeRequestDto;
+import com.hidiscuss.backend.controller.dto.CreateDiscussionRequestDto;
+import com.hidiscuss.backend.entity.Discussion;
+import com.hidiscuss.backend.entity.DiscussionState;
+import com.hidiscuss.backend.entity.LiveReviewAvailableTimes;
+import com.hidiscuss.backend.entity.User;
+import com.hidiscuss.backend.repository.DiscussionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DiscussionServiceTest {
+
+    @Mock
+    private DiscussionRepository discussionRepository;
+
+    @Mock
+    private DiscussionCodeService discussionCodeService;
+
+    @Mock
+    private DiscussionTagService discussionTagService;
+
+    @InjectMocks
+    private DiscussionService discussionService;
+
+    @BeforeEach
+    void setUp() {
+        when(discussionRepository.save(Mockito.any(Discussion.class))).thenAnswer(i -> i.getArgument(0));
+    }
+    @Test
+    void serviceIsDefined() {
+        assertThat(discussionService).isNotNull();
+    }
+
+    @Test
+    void createDiscussion_common() {
+        CreateDiscussionRequestDto dto = getCreateDiscussionRequestDto();
+        User user = new User();
+
+        Discussion discussion = discussionService.create(dto, user);
+
+        assertThat(discussion.getState()).isEqualTo(DiscussionState.NOT_REVIEWED);
+        assertThat(discussion.getUser()).isEqualTo(user);
+        assertThat(discussion.getQuestion()).isNotNull();
+    }
+
+    @Test
+    void createDiscussion_onlyCommentReview() {
+        CreateDiscussionRequestDto dto = getCreateDiscussionRequestDto();
+        dto.liveReviewRequired = false;
+        dto.liveReviewAvailableTimes = null;
+        User user = new User();
+
+        Discussion discussion = discussionService.create(dto, user);
+
+        assertThat(discussion.getLiveReviewRequired()).isFalse();
+        assertThat(discussion).isNotNull();
+    }
+
+    @Test
+    void createDiscussion_withLiveReview() {
+        CreateDiscussionRequestDto dto = getCreateDiscussionRequestDto();
+        dto.liveReviewRequired = true;
+        dto.liveReviewAvailableTimes = new LiveReviewAvailableTimes();
+        User user = new User();
+
+        Discussion discussion = discussionService.create(dto, user);
+
+        assertThat(discussion.getLiveReviewRequired()).isTrue();
+        assertThat(discussion.getLiveReviewAvailableTimes()).isNotNull();
+        assertThat(discussion).isNotNull();
+    }
+
+    private CreateDiscussionRequestDto getCreateDiscussionRequestDto() {
+        CreateDiscussionRequestDto dto = new CreateDiscussionRequestDto();
+        dto.question = "questionTest";
+        dto.liveReviewRequired = false;
+        dto.liveReviewAvailableTimes = null;
+        dto.discussionType = "DIRECT";
+        dto.gitRepositoryId = "gitRepositoryId";
+        dto.codes = List.of(getCreateDiscussionCodeRequestDto(), getCreateDiscussionCodeRequestDto());
+        dto.gitNodeId = "gitNodeId";
+        dto.usePriority = true;
+        dto.tagIds = List.of(1L, 2L);
+        dto.codes = null;
+        return dto;
+    }
+
+    private CreateDiscussionCodeRequestDto getCreateDiscussionCodeRequestDto() {
+        CreateDiscussionCodeRequestDto dto = new CreateDiscussionCodeRequestDto();
+        dto.content = "content";
+        dto.filename = "filename";
+        return dto;
+    }
+}


### PR DESCRIPTION
### 티켓
[CAPS-105](https://2022springcapstone.atlassian.net/browse/CAPS-105)
[CAPS-106](https://2022springcapstone.atlassian.net/browse/CAPS-106)

### 추가내용
- 커스텀 예외 추가 : `GithubException` `EmptyDiscussionCodeException`
- `Service` 객체 추가 : `DiscussionService`, `DiscussionCodeService`, `DiscussionTagService`, `GithubService`
- `ServiceTest` 객체 추가 : `DiscussionService`, `DiscussionCodeService`에 대한 테스트 객체 추가

### 변경내용
- `DiscussionController` 수정 : 파라미터 유효성 검사 & 서비스 연결
- `GithubController` 수정 : uri 수정, Service 연결
- `GlobalExceptionHandler` 수정 : 커스텀 예외 연결

### 논의사항
- `Github` 파일 단위 객체가 `patch`를 리턴하는데.. 프론트엔드에서 어떻게 사용할지 추후 논의 해야 할듯 합니다
- 이런 식으로 리턴함

```
@@ -0,0 +1,4 @@
+package com.hidiscuss.backend.repository;
+
+public interface CommentReviewDiffRepositoryCustom {
+}
```