### PR TITLE
 CAPS-125: 라이브 리뷰 예약 Controller

### DIFF
--- a/src/main/java/com/hidiscuss/backend/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/hidiscuss/backend/controller/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -23,6 +24,13 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(IllegalArgumentException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public String handleException(IllegalArgumentException e) {
+        logger.warn(e.getMessage());
+        return e.getMessage();
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String handleException(MissingServletRequestParameterException e) {
         logger.warn(e.getMessage());
         return e.getMessage();
     }

--- a/src/main/java/com/hidiscuss/backend/controller/ReviewReservationController.java
+++ b/src/main/java/com/hidiscuss/backend/controller/ReviewReservationController.java
@@ -1,0 +1,50 @@
+package com.hidiscuss.backend.controller;
+
+
+import com.hidiscuss.backend.controller.dto.CreateReviewReservationRequestDto;
+import com.hidiscuss.backend.controller.dto.ReviewReservationResponseDto;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.List;
+
+@RestController
+@RequestMapping("/reservation")
+public class ReviewReservationController {
+
+    @ApiOperation(value ="discussion Id를 받아 이미 예약된 리뷰들 반환")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "예약된 리뷰들 반환 (없는 경우 포함)"),
+            @ApiResponse(code = 400, message = "discussionId가 null 또는 Discussion이 존재하지 않음."),
+            @ApiResponse(code = 500, message = "서버 에러")
+    })
+    //TODO: Authenticated Method
+    @GetMapping("")
+    public List<ReviewReservationResponseDto> getReviewReservationByDiscussionId(
+            @RequestParam Long discussionId) {
+       /* if (discussionService.findById(discussionId) == null) {
+            throw new IllegalArgumentException("discussionId is not exist");
+        }*/
+        //reviewReservationService.findByDiscussionId(discussionId);
+        return null;
+    }
+
+    @ApiOperation(value = "새로운 라이브 리뷰 예약 추가")
+    @ApiResponses({
+            @ApiResponse(code = 201, message = "성공"),
+            @ApiResponse(code = 400, message ="잘못된 discussionId 또는 이미 예약된 시간"),
+            @ApiResponse(code = 500, message = "서버 에러")
+    })
+    @ResponseStatus(HttpStatus.CREATED)
+    //TODO: Authenticated Method
+    @PostMapping("")
+    public ReviewReservationResponseDto addReviewReservation(
+            @RequestBody @Valid CreateReviewReservationRequestDto createReviewResevationRequestDto
+    ) {
+        return null;
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/controller/dto/CreateReviewReservationRequestDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/CreateReviewReservationRequestDto.java
@@ -1,0 +1,16 @@
+package com.hidiscuss.backend.controller.dto;
+
+import com.hidiscuss.backend.entity.ReviewReservation;
+
+import javax.validation.constraints.Future;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public class CreateReviewReservationRequestDto {
+    @NotNull
+    public Long discussionId;
+
+    @NotNull
+    @Future
+    public LocalDateTime reviewDate;
+}

--- a/src/main/java/com/hidiscuss/backend/controller/dto/ReviewReservationResponseDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/ReviewReservationResponseDto.java
@@ -1,0 +1,41 @@
+package com.hidiscuss.backend.controller.dto;
+
+import com.hidiscuss.backend.entity.ReviewReservation;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ReviewReservationResponseDto {
+
+    private Long id;
+    //private UserResponseDto user;
+    //private ReviewResponseDto review;
+    private DiscussionResponseDto discussion;
+    private LocalDateTime reviewDate;
+    private Boolean reviewerParticipated;
+    private Boolean revieweeParticipated;
+    private Boolean isdone;
+
+    private ReviewReservationResponseDto(Long id, DiscussionResponseDto discussion, LocalDateTime reviewDate, Boolean reviewerParticipated, Boolean revieweeParticipated, Boolean isdone) {
+        this.id = id;
+        this.discussion = discussion;
+        this.reviewDate = reviewDate;
+        this.reviewerParticipated = reviewerParticipated;
+        this.revieweeParticipated = revieweeParticipated;
+        this.isdone = isdone;
+        //this.user = user;
+        //this.review = review;
+    }
+
+    public static ReviewReservationResponseDto fromEntity(ReviewReservation reviewReservation) {
+        return new ReviewReservationResponseDto(
+                reviewReservation.getId(),
+                DiscussionResponseDto.fromEntity(reviewReservation.getDiscussion()),
+                reviewReservation.getReviewDate(),
+                reviewReservation.getReviewerParticipated(),
+                reviewReservation.getRevieweeParticipated(),
+                reviewReservation.getIsdone()
+        );
+    }
+}


### PR DESCRIPTION
### 티켓
[CAPS-125](https://2022springcapstone.atlassian.net/browse/CAPS-125)

### 추가내용
- `MissingServletRequestParameterException` 핸들러 추가 : Request Parameter 유효성 예외 핸들링
- 라이브 리뷰 예약 관련 API 추가

### 논의내용
- API Path를 `/reservation` 으로 했는데 적절할까요?
- (PR에는 포함되지 않지만) `ReviewReservation` 엔티티 네이밍을 수정하면 좋겠습니다(`reviewDate` -> `reviewStartDate`)