### PR TITLE
CAPS 135: Discussion 제목 생성

### DIFF
--- a/src/main/java/com/hidiscuss/backend/controller/dto/CreateDiscussionRequestDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/CreateDiscussionRequestDto.java
@@ -12,6 +12,9 @@ import java.util.List;
 
 public class CreateDiscussionRequestDto {
     @NotNull
+    public String title;
+
+    @NotNull
 //    @Size(min = 1, max = 1234)
     public String question;
 
@@ -43,6 +46,7 @@ public class CreateDiscussionRequestDto {
         return Discussion.builder()
                 .question(dto.question)
                 .user(user)
+                .title(dto.title)
                 .liveReviewRequired(dto.liveReviewRequired)
                 .liveReviewAvailableTimes(dto.liveReviewAvailableTimes)
                 .priority(dto.usePriority ? 255L : 0L)

--- a/src/main/java/com/hidiscuss/backend/controller/dto/DiscussionResponseDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/DiscussionResponseDto.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 @Getter
 public class DiscussionResponseDto extends BaseResponseDto {
     private Long id;
+    private String title;
     private String question;
     private Boolean liveReviewRequired;
     private LiveReviewAvailableTimes liveReviewAvailableTimes;
@@ -21,6 +22,7 @@ public class DiscussionResponseDto extends BaseResponseDto {
         DiscussionResponseDto dto = new DiscussionResponseDto();
         dto.setBaseResponse(entity);
         dto.id = entity.getId();
+        dto.title = entity.getTitle();
         dto.question = entity.getQuestion();
         dto.liveReviewRequired = entity.getLiveReviewRequired();
         dto.liveReviewAvailableTimes = entity.getLiveReviewAvailableTimes();

--- a/src/main/java/com/hidiscuss/backend/entity/Discussion.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Discussion.java
@@ -16,6 +16,9 @@ public class Discussion extends BaseEntity {
     @Column(name = "id", nullable = false)
     private Long id;
 
+    @Column(name = "title", nullable = false)
+    private String title;
+
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "enum('NOT_REVIEWED', 'REVIEWING', 'COMPLETED') default 'NOT_REVIEWED'", name = "state", nullable = false)
     private DiscussionState state;
@@ -38,9 +41,10 @@ public class Discussion extends BaseEntity {
     private Long priority;
 
     @Builder
-    public Discussion(User user, String question, Boolean liveReviewRequired, LiveReviewAvailableTimes liveReviewAvailableTimes, Long priority) {
+    public Discussion(User user, String question, String title, Boolean liveReviewRequired, LiveReviewAvailableTimes liveReviewAvailableTimes, Long priority) {
         this.state = DiscussionState.NOT_REVIEWED;
         this.user = user;
+        this.title = title;
         this.question = question;
         this.liveReviewRequired = liveReviewRequired;
         this.liveReviewAvailableTimes = liveReviewAvailableTimes;


### PR DESCRIPTION
## 티켓
[CAPS-135](https://2022springcapstone.atlassian.net/browse/CAPS-135)

## 변경사항
- `Discussion` 엔티티에 `title` 추가
- `CreateDiscussionRequestDto`, `DiscussionResponseDto`에 `title` 추가