### PR TITLE
CAPS104 : Tag API 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ dependencies {
 	// Swagger
 	implementation 'io.springfox:springfox-boot-starter:3.0.0'
 	implementation 'io.springfox:springfox-swagger-ui:3.0.0'
-
+	implementation 'io.springfox:springfox-bean-validators:3.0.0'
 	//spring security oauth2
 	implementation 'org.springframework.boot:spring-boot-starter-hateoas'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
@@ -82,10 +82,6 @@ jib {
 			}
 		}
 	}
-	/*
-	 로컬 빌드 시 아래 명령어 사용
-	 gradle jibBuildTar
-	 */
 	to {
 		image = "075730933478.dkr.ecr.ap-northeast-2.amazonaws.com/backend-spring"
 		tags = ["latest", "${getGitHash()}"]
@@ -95,6 +91,5 @@ jib {
 		jvmFlags = ["-Xms128m", "-Xmx128m", "-Dspring.profiles.active=prod"]
 		creationTime = "USE_CURRENT_TIMESTAMP"
 		ports = ['8080']
-		environment = [SPRING_CONFIG_LOCATION:"file:/app/config/*/application.yml"]
 	}
 }

--- a/src/main/java/com/hidiscuss/backend/config/SwaggerConfig.java
+++ b/src/main/java/com/hidiscuss/backend/config/SwaggerConfig.java
@@ -2,6 +2,7 @@ package com.hidiscuss.backend.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
@@ -14,6 +15,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 @Configuration
+@Profile({ "dev", "test" }) // only active in dev and test profiles
 public class SwaggerConfig {
 
     private ApiInfo swaggerInfo() {

--- a/src/main/java/com/hidiscuss/backend/controller/TagController.java
+++ b/src/main/java/com/hidiscuss/backend/controller/TagController.java
@@ -1,0 +1,28 @@
+package com.hidiscuss.backend.controller;
+
+import com.hidiscuss.backend.controller.dto.TagResponseDto;
+import com.hidiscuss.backend.entity.Tag;
+import com.hidiscuss.backend.service.TagService;
+import io.swagger.annotations.ApiOperation;
+import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/tag")
+@AllArgsConstructor
+public class TagController {
+
+    private final TagService tagService;
+
+    @ApiOperation(value = "존재하는 태그를 반환")
+    @GetMapping("")
+    public List<TagResponseDto> findAll() {
+        List<Tag> tags = tagService.findAll();
+        return tags.stream().map(TagResponseDto::fromEntity).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/controller/dto/TagResponseDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/TagResponseDto.java
@@ -12,7 +12,7 @@ public class TagResponseDto {
         this.id = id;
         this.name = name;
     }
-    static TagResponseDto fromEntity(Tag tag) {
+    public static TagResponseDto fromEntity(Tag tag) {
         TagResponseDto dto = new TagResponseDto(tag.getId(), tag.getName());
         return dto;
     }

--- a/src/main/java/com/hidiscuss/backend/service/TagService.java
+++ b/src/main/java/com/hidiscuss/backend/service/TagService.java
@@ -1,0 +1,35 @@
+package com.hidiscuss.backend.service;
+
+import com.hidiscuss.backend.entity.Tag;
+import com.hidiscuss.backend.repository.TagRepository;
+import com.hidiscuss.backend.utils.DbInitilization;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import javax.transaction.Transactional;
+import java.util.List;
+
+@Service
+@Transactional
+@AllArgsConstructor
+@Slf4j
+public class TagService {
+    private final TagRepository tagRepository;
+
+    @PostConstruct
+    private void initTagService() {
+        List<Tag> tags = this.findAll();
+        if (!tags.isEmpty()) {
+            return;
+        }
+        log.info("Initializing tag service");
+        tags = DbInitilization.getInitialTags();
+        tagRepository.saveAll(tags);
+    }
+
+    public List<Tag> findAll() {
+        return tagRepository.findAll();
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/utils/DbInitilization.java
+++ b/src/main/java/com/hidiscuss/backend/utils/DbInitilization.java
@@ -1,0 +1,37 @@
+package com.hidiscuss.backend.utils;
+
+import com.hidiscuss.backend.entity.Tag;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class DbInitilization {
+    public static List<Tag> getInitialTags() {
+        List<String> tagNames = List.of(
+                "react",
+                "vue",
+                "nextjs",
+                "spring",
+                "express",
+                "django",
+                "flask",
+                "c",
+                "c++",
+                "python",
+                "java",
+                "javascript",
+                "typescript",
+                "kotlin",
+                "tensorflow",
+                "machine learning",
+                "web frontend",
+                "web backend",
+                "android",
+                "ios",
+                "swift",
+                "sql",
+                "nosql"
+        );
+        return tagNames.stream().map(tag -> Tag.builder().name(tag).build()).collect(Collectors.toList());
+    }
+}

--- a/src/test/java/com/hidiscuss/backend/service/TagServiceTest.java
+++ b/src/test/java/com/hidiscuss/backend/service/TagServiceTest.java
@@ -1,0 +1,30 @@
+package com.hidiscuss.backend.service;
+
+import com.hidiscuss.backend.repository.TagRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+public class TagServiceTest {
+    @Mock
+    private TagRepository tagRepository;
+
+    @InjectMocks
+    private TagService tagService;
+
+    @Test
+    void serviceIsDefined() {
+        assertThat(tagService).isNotNull();
+    }
+
+//    @Test
+//    void findAll_returnsAllTags() {
+//        assertThat(tagService.findAll()).isNotNull();
+//    }
+//
+}


### PR DESCRIPTION
### 티켓
CAPS-104

### 추가사항
- `GET /tag` API 추가
- `TagService` 클래스 : `findAll` 메소드와 태그 초기화를 위한 `PostConstructor` 추가했습니다
- `DbInitilization` 클래스 : 초기 태그를 리턴해주는 static method 가지는 클래스

### 기타 변경사항 ( PR 같이 묶어서 올려요..! )
- `io.springfox:springfox-bean-validators:3.0.0` 의존성 추가 : 저희가 쓰는 dto 검증 어노테이션까지 인식해서 swagger 문서 생성해줌! [link](https://springfox.github.io/springfox/docs/current/#springfox-support-for-jsr-303)
- API 문서가 `dev` `test` 환경에서만 뜨게 했습니다 ~