### PR TITLE
CAPS 112~113: CommentReview 생성 Service/Test 작성 (지난 스프린트 수정)

### DIFF
--- a/src/main/java/com/hidiscuss/backend/controller/ReviewController.java
+++ b/src/main/java/com/hidiscuss/backend/controller/ReviewController.java
@@ -9,6 +9,7 @@ import com.hidiscuss.backend.service.ReviewService;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -29,10 +30,11 @@ public class ReviewController {
             @ApiResponse(code = 400, message = "잘못된 요청"),
             @ApiResponse(code = 500, message = "서버 오류")
     })
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("")
     public CommentReviewResponseDto saveCommentReview(@RequestParam("type") ReviewType reviewType, @RequestBody @Valid CreateCommentReviewRequestDto requestDto) {
         User user = User.builder().id(7000L).build();
-        Review review = reviewService.saveReviewAndCommentDiffList(user, requestDto, reviewType);
+        Review review = reviewService.createCommentReview(user, requestDto, reviewType);
         return CommentReviewResponseDto.fromEntity(review);
     }
 
@@ -42,10 +44,11 @@ public class ReviewController {
             @ApiResponse(code = 400, message = "잘못된 요청"),
             @ApiResponse(code = 500, message = "서버 오류")
     })
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("{reviewId}/thread")
     public ThreadResponseDto saveThread(@PathVariable("reviewId") Long reviewId, @RequestBody @Valid CreateThreadRequestDto requestDto) {
         User user = User.builder().id(7000L).build();
-        ReviewThread reviewThread = reviewService.saveThread(user, requestDto, reviewId);
+        ReviewThread reviewThread = reviewService.createThread(user, requestDto, reviewId);
         return ThreadResponseDto.fromEntity(reviewThread);
     }
 }

--- a/src/main/java/com/hidiscuss/backend/controller/ReviewController.java
+++ b/src/main/java/com/hidiscuss/backend/controller/ReviewController.java
@@ -23,7 +23,7 @@ public class ReviewController {
         this.reviewService = reviewService;
     }
 
-    @ApiOperation(value="comment review 저장", notes="이 api는 comment review를 저장합니다. requestBody로 온 comment review diff도 개수만큼 테이블에 저장합니다.")
+    @ApiOperation(value="comment review 생성", notes="이 api는 comment review를 생성합니다. requestBody로 온 comment review diff도 개수만큼 테이블에 저장합니다.")
     @ApiResponses({
             @ApiResponse(code = 201, message = "새로운 comment review 생성 성공"),
             @ApiResponse(code = 400, message = "잘못된 요청"),
@@ -31,9 +31,8 @@ public class ReviewController {
     })
     @PostMapping("")
     public CommentReviewResponseDto saveCommentReview(@RequestParam("type") ReviewType reviewType, @RequestBody @Valid CreateCommentReviewRequestDto requestDto) {
-        User user = User.builder().id(1111L).build();
-        Review review = reviewService.saveReview(user, requestDto, reviewType);
-        review = reviewService.saveCommentReviewDiff(requestDto, review);
+        User user = User.builder().id(7000L).build();
+        Review review = reviewService.saveReviewAndCommentDiffList(user, requestDto, reviewType);
         return CommentReviewResponseDto.fromEntity(review);
     }
 
@@ -45,7 +44,7 @@ public class ReviewController {
     })
     @PostMapping("{reviewId}/thread")
     public ThreadResponseDto saveThread(@PathVariable("reviewId") Long reviewId, @RequestBody @Valid CreateThreadRequestDto requestDto) {
-        User user = User.builder().id(1111L).build();
+        User user = User.builder().id(7000L).build();
         ReviewThread reviewThread = reviewService.saveThread(user, requestDto, reviewId);
         return ThreadResponseDto.fromEntity(reviewThread);
     }

--- a/src/main/java/com/hidiscuss/backend/controller/ReviewController.java
+++ b/src/main/java/com/hidiscuss/backend/controller/ReviewController.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.NoSuchElementException;
 
 @RestController
 @RequestMapping("/review")
@@ -48,7 +49,8 @@ public class ReviewController {
     @PostMapping("{reviewId}/thread")
     public ThreadResponseDto saveThread(@PathVariable("reviewId") Long reviewId, @RequestBody @Valid CreateThreadRequestDto requestDto) {
         User user = User.builder().id(7000L).build();
-        ReviewThread reviewThread = reviewService.createThread(user, requestDto, reviewId);
+        Review review = reviewService.findByIdFetchOrNull(reviewId);
+        ReviewThread reviewThread = reviewService.createThread(user, requestDto, review);
         return ThreadResponseDto.fromEntity(reviewThread);
     }
 }

--- a/src/main/java/com/hidiscuss/backend/controller/dto/CommentReviewDiffDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/CommentReviewDiffDto.java
@@ -6,6 +6,7 @@ import com.hidiscuss.backend.entity.Review;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.lang.Nullable;
 
 import javax.validation.constraints.NotNull;
 
@@ -23,7 +24,7 @@ public class CommentReviewDiffDto {
     @NotNull
     public String codeLocate;
 
-    @NotNull
+    @Nullable
     public String comment;
 
     public static CommentReviewDiff toEntity(CommentReviewDiffDto dto, Review review, DiscussionCode code) {

--- a/src/main/java/com/hidiscuss/backend/controller/dto/CommentReviewResponseDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/CommentReviewResponseDto.java
@@ -29,9 +29,9 @@ public class CommentReviewResponseDto extends BaseResponseDto {
         dto.id = entity.getId();
         dto.reviewer = UserResponseDto.fromEntity(entity.getReviewer());
         dto.discussion = DiscussionResponseDto.fromEntity(entity.getDiscussion());
-        Optional<List<CommentReviewDiff>> list = Optional.ofNullable(entity.getDiffList());
+        Optional<List<CommentReviewDiff>> list = Optional.ofNullable(entity.getCommentDiffList());
         if (list.isPresent()) {
-            for(CommentReviewDiff item: entity.getDiffList()) {
+            for(CommentReviewDiff item: entity.getCommentDiffList()) {
                 dto.diffList.add(CommentReviewDiffDto.fromEntity(item));
             }
         }

--- a/src/main/java/com/hidiscuss/backend/entity/CommentReviewDiff.java
+++ b/src/main/java/com/hidiscuss/backend/entity/CommentReviewDiff.java
@@ -27,4 +27,17 @@ public class CommentReviewDiff extends ReviewDiff {
     public CommentReviewDiff() {
         super();
     }
+
+    public void setReview(Review review) {
+        super.review = review;
+        review.getDiffList().add(this);
+    }
+
+    @Override
+    public String toString() {
+        return "CommentReviewDiff{" +
+                "codeLocate='" + codeLocate + '\'' +
+                ", comment='" + comment + '\'' +
+                '}';
+    }
 }

--- a/src/main/java/com/hidiscuss/backend/entity/CommentReviewDiff.java
+++ b/src/main/java/com/hidiscuss/backend/entity/CommentReviewDiff.java
@@ -30,7 +30,7 @@ public class CommentReviewDiff extends ReviewDiff {
 
     public void setReview(Review review) {
         super.review = review;
-        review.getDiffList().add(this);
+        review.getCommentDiffList().add(this);
     }
 
     @Override

--- a/src/main/java/com/hidiscuss/backend/entity/DiscussionCode.java
+++ b/src/main/java/com/hidiscuss/backend/entity/DiscussionCode.java
@@ -43,7 +43,8 @@ public class DiscussionCode extends BaseEntity {
     private String content;
 
     @Builder
-    public DiscussionCode(Discussion discussion, String sha, String filename, Status status, Long additions, Long deletions, Long changes, String content) {
+    public DiscussionCode(Long id, Discussion discussion, String sha, String filename, Status status, Long additions, Long deletions, Long changes, String content) {
+        this.id = id;
         this.discussion = discussion;
         this.sha = sha;
         this.filename = filename;

--- a/src/main/java/com/hidiscuss/backend/entity/Review.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Review.java
@@ -31,7 +31,10 @@ public class Review extends BaseEntity {
     private Discussion discussion;
 
     @OneToMany(mappedBy = "review")
-    private List<CommentReviewDiff> diffList = new ArrayList<>();
+    private List<CommentReviewDiff> commentDiffList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "review")
+    private List<LiveReviewDiff> liveDiffList = new ArrayList<>();
 
     @Column(columnDefinition ="boolean default false", name = "accepted", nullable = false)
     private Boolean accepted;
@@ -41,11 +44,12 @@ public class Review extends BaseEntity {
     private ReviewType reviewType;
 
     @Builder
-    public Review(Long id, User reviewer, Discussion discussion, List<CommentReviewDiff> diffList, Boolean accepted, ReviewType reviewType) {
+    public Review(Long id, User reviewer, Discussion discussion, List<CommentReviewDiff> commentDiffList, List<LiveReviewDiff> liveDiffList, Boolean accepted, ReviewType reviewType) {
         this.id = id;
         this.reviewer = reviewer;
         this.discussion = discussion;
-        this.diffList = diffList;
+        this.commentDiffList = commentDiffList;
+        this.liveDiffList = liveDiffList;
         this.accepted = accepted;
         this.reviewType = reviewType;
     }
@@ -56,9 +60,14 @@ public class Review extends BaseEntity {
                 "id=" + id +
                 ", reviewer=" + reviewer +
                 ", discussion=" + discussion +
-                ", diffList=" + diffList +
+                ", commentDiffList=" + commentDiffList +
+                ", liveDiffList=" + liveDiffList +
                 ", accepted=" + accepted +
                 ", reviewType=" + reviewType +
                 '}';
+    }
+
+    public void setCommentDiffList(List<CommentReviewDiff> commentDiffList) {
+        this.commentDiffList = commentDiffList;
     }
 }

--- a/src/main/java/com/hidiscuss/backend/entity/Review.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Review.java
@@ -50,7 +50,15 @@ public class Review extends BaseEntity {
         this.reviewType = reviewType;
     }
 
-    public void setDiffList(List<CommentReviewDiff> diffList) {
-        this.diffList = diffList;
+    @Override
+    public String toString() {
+        return "Review{" +
+                "id=" + id +
+                ", reviewer=" + reviewer +
+                ", discussion=" + discussion +
+                ", diffList=" + diffList +
+                ", accepted=" + accepted +
+                ", reviewType=" + reviewType +
+                '}';
     }
 }

--- a/src/main/java/com/hidiscuss/backend/entity/ReviewDiff.java
+++ b/src/main/java/com/hidiscuss/backend/entity/ReviewDiff.java
@@ -19,7 +19,7 @@ abstract class ReviewDiff extends BaseEntity {
 
     @ManyToOne
     @JoinColumn(name = "review_id", nullable = false)
-    private Review review;
+    Review review;
 
     @ManyToOne
     @JoinColumn(name = "discussion_code_id", nullable = false)

--- a/src/main/java/com/hidiscuss/backend/repository/DiscussionCodeRepository.java
+++ b/src/main/java/com/hidiscuss/backend/repository/DiscussionCodeRepository.java
@@ -2,6 +2,13 @@ package com.hidiscuss.backend.repository;
 
 import com.hidiscuss.backend.entity.DiscussionCode;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
+@Repository
 public interface DiscussionCodeRepository extends JpaRepository<DiscussionCode, Long>, DiscussionCodeRepositoryCustom {
+    @Query("select d from DiscussionCode d left join fetch d.discussion")
+    Optional<DiscussionCode> findByIdFetchJoin(Long id);
 }

--- a/src/main/java/com/hidiscuss/backend/repository/DiscussionCodeRepository.java
+++ b/src/main/java/com/hidiscuss/backend/repository/DiscussionCodeRepository.java
@@ -3,12 +3,13 @@ package com.hidiscuss.backend.repository;
 import com.hidiscuss.backend.entity.DiscussionCode;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
 public interface DiscussionCodeRepository extends JpaRepository<DiscussionCode, Long>, DiscussionCodeRepositoryCustom {
-    @Query("select d from DiscussionCode d left join fetch d.discussion")
-    Optional<DiscussionCode> findByIdFetchJoin(Long id);
+    @Query("select d from DiscussionCode d left join fetch d.discussion where d.id = :id")
+    Optional<DiscussionCode> findByIdFetchJoin(@Param("id") Long id);
 }

--- a/src/main/java/com/hidiscuss/backend/repository/DiscussionCodeRepository.java
+++ b/src/main/java/com/hidiscuss/backend/repository/DiscussionCodeRepository.java
@@ -6,10 +6,10 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface DiscussionCodeRepository extends JpaRepository<DiscussionCode, Long>, DiscussionCodeRepositoryCustom {
-    @Query("select d from DiscussionCode d left join fetch d.discussion where d.id = :id")
-    Optional<DiscussionCode> findByIdFetchJoin(@Param("id") Long id);
+
 }

--- a/src/main/java/com/hidiscuss/backend/repository/DiscussionCodeRepositoryCustom.java
+++ b/src/main/java/com/hidiscuss/backend/repository/DiscussionCodeRepositoryCustom.java
@@ -1,4 +1,9 @@
 package com.hidiscuss.backend.repository;
 
+import com.hidiscuss.backend.entity.DiscussionCode;
+
+import java.util.List;
+
 public interface DiscussionCodeRepositoryCustom {
+    List<DiscussionCode> findByIdListFetchJoin(List<Long> list);
 }

--- a/src/main/java/com/hidiscuss/backend/repository/DiscussionCodeRepositoryCustom.java
+++ b/src/main/java/com/hidiscuss/backend/repository/DiscussionCodeRepositoryCustom.java
@@ -5,5 +5,5 @@ import com.hidiscuss.backend.entity.DiscussionCode;
 import java.util.List;
 
 public interface DiscussionCodeRepositoryCustom {
-    List<DiscussionCode> findByIdListFetchJoin(List<Long> list);
+    List<DiscussionCode> findByIdListFetch(List<Long> list);
 }

--- a/src/main/java/com/hidiscuss/backend/repository/DiscussionCodeRepositoryImpl.java
+++ b/src/main/java/com/hidiscuss/backend/repository/DiscussionCodeRepositoryImpl.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public class DiscussionCodeRepositoryImpl implements DiscussionRepositoryCustom{
+public class DiscussionCodeRepositoryImpl implements DiscussionCodeRepositoryCustom{
     private final JPAQueryFactory queryFactory;
     private final QDiscussionCode qDiscussionCode = QDiscussionCode.discussionCode;
 
@@ -18,11 +18,9 @@ public class DiscussionCodeRepositoryImpl implements DiscussionRepositoryCustom{
     }
 
     @Override
-    public List<DiscussionCode> findByIdListFetchJoin(List<Long> list) {
-        List<DiscussionCode> result = queryFactory.selectFrom(qDiscussionCode)
+    public List<DiscussionCode> findByIdListFetch(List<Long> list) {
+        return queryFactory.selectFrom(qDiscussionCode)
                 .where(qDiscussionCode.id.in(list))
                 .fetch();
-        return result;
     }
-
 }

--- a/src/main/java/com/hidiscuss/backend/repository/DiscussionCodeRepositoryImpl.java
+++ b/src/main/java/com/hidiscuss/backend/repository/DiscussionCodeRepositoryImpl.java
@@ -1,13 +1,28 @@
 package com.hidiscuss.backend.repository;
 
+import com.hidiscuss.backend.controller.dto.CommentReviewDiffDto;
+import com.hidiscuss.backend.entity.DiscussionCode;
+import com.hidiscuss.backend.entity.QDiscussionCode;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
-public class DiscussionCodeRepositoryImpl {
+public class DiscussionCodeRepositoryImpl implements DiscussionRepositoryCustom{
     private final JPAQueryFactory queryFactory;
+    private final QDiscussionCode qDiscussionCode = QDiscussionCode.discussionCode;
 
     public DiscussionCodeRepositoryImpl(JPAQueryFactory queryFactory) {
         this.queryFactory = queryFactory;
     }
+
+    @Override
+    public List<DiscussionCode> findByIdListFetchJoin(List<Long> list) {
+        List<DiscussionCode> result = queryFactory.selectFrom(qDiscussionCode)
+                .where(qDiscussionCode.id.in(list))
+                .fetch();
+        return result;
+    }
+
 }

--- a/src/main/java/com/hidiscuss/backend/repository/DiscussionRepository.java
+++ b/src/main/java/com/hidiscuss/backend/repository/DiscussionRepository.java
@@ -4,10 +4,11 @@ import com.hidiscuss.backend.entity.Discussion;
 import com.hidiscuss.backend.entity.DiscussionCode;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface DiscussionRepository extends JpaRepository<Discussion, Long>, DiscussionRepositoryCustom {
-    @Query("select d from Discussion d left join fetch d.user")
-    Optional<Discussion> findByIdFetchJoin(Long id);
+    @Query("select d from Discussion d left join fetch d.user where d.id = :id")
+    Optional<Discussion> findByIdFetchJoin(@Param("id") Long id);
 }

--- a/src/main/java/com/hidiscuss/backend/repository/DiscussionRepository.java
+++ b/src/main/java/com/hidiscuss/backend/repository/DiscussionRepository.java
@@ -9,6 +9,5 @@ import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface DiscussionRepository extends JpaRepository<Discussion, Long>, DiscussionRepositoryCustom {
-    @Query("select d from Discussion d left join fetch d.user where d.id = :id")
-    Optional<Discussion> findByIdFetchJoin(@Param("id") Long id);
+
 }

--- a/src/main/java/com/hidiscuss/backend/repository/DiscussionRepository.java
+++ b/src/main/java/com/hidiscuss/backend/repository/DiscussionRepository.java
@@ -1,7 +1,13 @@
 package com.hidiscuss.backend.repository;
 
 import com.hidiscuss.backend.entity.Discussion;
+import com.hidiscuss.backend.entity.DiscussionCode;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface DiscussionRepository extends JpaRepository<Discussion, Long>, DiscussionRepositoryCustom {
+    @Query("select d from Discussion d left join fetch d.user")
+    Optional<Discussion> findByIdFetchJoin(Long id);
 }

--- a/src/main/java/com/hidiscuss/backend/repository/DiscussionRepositoryCustom.java
+++ b/src/main/java/com/hidiscuss/backend/repository/DiscussionRepositoryCustom.java
@@ -1,4 +1,10 @@
 package com.hidiscuss.backend.repository;
 
+import com.hidiscuss.backend.controller.dto.CommentReviewDiffDto;
+import com.hidiscuss.backend.entity.DiscussionCode;
+
+import java.util.List;
+
 public interface DiscussionRepositoryCustom {
+    List<DiscussionCode> findByIdListFetchJoin(List<Long> list);
 }

--- a/src/main/java/com/hidiscuss/backend/repository/DiscussionRepositoryCustom.java
+++ b/src/main/java/com/hidiscuss/backend/repository/DiscussionRepositoryCustom.java
@@ -1,10 +1,10 @@
 package com.hidiscuss.backend.repository;
 
-import com.hidiscuss.backend.controller.dto.CommentReviewDiffDto;
-import com.hidiscuss.backend.entity.DiscussionCode;
+import com.hidiscuss.backend.entity.Discussion;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface DiscussionRepositoryCustom {
-    List<DiscussionCode> findByIdListFetchJoin(List<Long> list);
+    Discussion findByIdFetchOrNull(Long id);
 }

--- a/src/main/java/com/hidiscuss/backend/repository/DiscussionRepositoryImpl.java
+++ b/src/main/java/com/hidiscuss/backend/repository/DiscussionRepositoryImpl.java
@@ -1,13 +1,26 @@
 package com.hidiscuss.backend.repository;
 
+import com.hidiscuss.backend.entity.Discussion;
+import com.hidiscuss.backend.entity.QDiscussion;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
-public class DiscussionRepositoryImpl {
+public class DiscussionRepositoryImpl implements DiscussionRepositoryCustom{
     private final JPAQueryFactory queryFactory;
+    private final QDiscussion qDiscussion = QDiscussion.discussion;
 
     public DiscussionRepositoryImpl(JPAQueryFactory queryFactory) {
         this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public Discussion findByIdFetchOrNull(Long id) {
+        return queryFactory.selectFrom(qDiscussion)
+                .where(qDiscussion.id.eq(id))
+                .fetchOne();
     }
 }

--- a/src/main/java/com/hidiscuss/backend/repository/ReviewRepository.java
+++ b/src/main/java/com/hidiscuss/backend/repository/ReviewRepository.java
@@ -2,6 +2,11 @@ package com.hidiscuss.backend.repository;
 
 import com.hidiscuss.backend.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRepositoryCustom {
+    @Query("select r from Review r left join fetch r.reviewer left join fetch r.discussion")
+    Optional<Review> findByIdFetchJoin(Long reviewId);
 }

--- a/src/main/java/com/hidiscuss/backend/repository/ReviewRepository.java
+++ b/src/main/java/com/hidiscuss/backend/repository/ReviewRepository.java
@@ -8,6 +8,4 @@ import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRepositoryCustom {
-    @Query("select r from Review r left join fetch r.reviewer left join fetch r.discussion where r.id = :id")
-    Optional<Review> findByIdFetchJoin(@Param("id") Long reviewId);
 }

--- a/src/main/java/com/hidiscuss/backend/repository/ReviewRepository.java
+++ b/src/main/java/com/hidiscuss/backend/repository/ReviewRepository.java
@@ -3,10 +3,11 @@ package com.hidiscuss.backend.repository;
 import com.hidiscuss.backend.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRepositoryCustom {
-    @Query("select r from Review r left join fetch r.reviewer left join fetch r.discussion")
-    Optional<Review> findByIdFetchJoin(Long reviewId);
+    @Query("select r from Review r left join fetch r.reviewer left join fetch r.discussion where r.id = :id")
+    Optional<Review> findByIdFetchJoin(@Param("id") Long reviewId);
 }

--- a/src/main/java/com/hidiscuss/backend/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/com/hidiscuss/backend/repository/ReviewRepositoryCustom.java
@@ -1,4 +1,9 @@
 package com.hidiscuss.backend.repository;
 
+import com.hidiscuss.backend.entity.Discussion;
+import com.hidiscuss.backend.entity.Review;
+
 public interface ReviewRepositoryCustom {
+
+    Review findByIdFetchOrNull(Long id);
 }

--- a/src/main/java/com/hidiscuss/backend/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/hidiscuss/backend/repository/ReviewRepositoryImpl.java
@@ -1,13 +1,25 @@
 package com.hidiscuss.backend.repository;
 
+import com.hidiscuss.backend.entity.QReview;
+import com.hidiscuss.backend.entity.Review;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.stereotype.Repository;
 
+import javax.persistence.Id;
+
 @Repository
-public class ReviewRepositoryImpl {
+public class ReviewRepositoryImpl implements ReviewRepositoryCustom{
     private final JPAQueryFactory queryFactory;
+    private final QReview qReview = QReview.review;
 
     public ReviewRepositoryImpl(JPAQueryFactory queryFactory) {
         this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public Review findByIdFetchOrNull(Long id) {
+        return queryFactory.selectFrom(qReview)
+                .where(qReview.id.eq(id))
+                .fetchOne();
     }
 }

--- a/src/main/java/com/hidiscuss/backend/service/CommentReviewDiffService.java
+++ b/src/main/java/com/hidiscuss/backend/service/CommentReviewDiffService.java
@@ -32,7 +32,7 @@ public class CommentReviewDiffService {
         if (codeList.size() != 0) {
             for (int i = 0; i < list.size(); i++) {
                 for (int j = 0; j < codeList.size(); j++) {
-                    if (list.get(i).getDiscussionCode().getId() == codeList.get(j).getId()) {
+                    if (list.get(i).getDiscussionCode().getId().equals(codeList.get(j).getId())) {
                         CommentReviewDiffDto tmpDto = list.get(i);
                         diffList.add(
                                 CommentReviewDiff.builder()

--- a/src/main/java/com/hidiscuss/backend/service/CommentReviewDiffService.java
+++ b/src/main/java/com/hidiscuss/backend/service/CommentReviewDiffService.java
@@ -1,0 +1,36 @@
+package com.hidiscuss.backend.service;
+
+import com.hidiscuss.backend.controller.dto.CommentReviewDiffDto;
+import com.hidiscuss.backend.controller.dto.CreateCommentReviewRequestDto;
+import com.hidiscuss.backend.entity.CommentReviewDiff;
+import com.hidiscuss.backend.entity.DiscussionCode;
+import com.hidiscuss.backend.entity.Review;
+import com.hidiscuss.backend.repository.CommentReviewDiffRepository;
+import com.hidiscuss.backend.repository.DiscussionCodeRepository;
+import com.hidiscuss.backend.repository.ReviewRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@Service
+@AllArgsConstructor
+public class CommentReviewDiffService {
+    private final ReviewRepository reviewRepository;
+    private final CommentReviewDiffRepository commentReviewDiffRepository;
+    private final DiscussionCodeRepository discussionCodeRepository;
+
+    public Review saveCommentReviewDiff(CreateCommentReviewRequestDto dto, Review review) {
+        List<CommentReviewDiffDto> list = dto.diffList;
+        for(CommentReviewDiffDto item : list) {
+            DiscussionCode code = discussionCodeRepository
+                    .findById(item.getDiscussionCode().getId())
+                    .orElseThrow(() -> new NoSuchElementException("discussionCodeId가 없습니다."));
+            CommentReviewDiff commentReviewDiff = CommentReviewDiffDto.toEntity(item, review, code);
+            commentReviewDiff.setReview(review);
+            commentReviewDiffRepository.save(commentReviewDiff);
+        }
+        return review;
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/service/CommentReviewDiffService.java
+++ b/src/main/java/com/hidiscuss/backend/service/CommentReviewDiffService.java
@@ -1,36 +1,31 @@
 package com.hidiscuss.backend.service;
 
 import com.hidiscuss.backend.controller.dto.CommentReviewDiffDto;
-import com.hidiscuss.backend.controller.dto.CreateCommentReviewRequestDto;
 import com.hidiscuss.backend.entity.CommentReviewDiff;
 import com.hidiscuss.backend.entity.DiscussionCode;
 import com.hidiscuss.backend.entity.Review;
 import com.hidiscuss.backend.repository.CommentReviewDiffRepository;
 import com.hidiscuss.backend.repository.DiscussionCodeRepository;
-import com.hidiscuss.backend.repository.ReviewRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.NoSuchElementException;
 
 @Service
 @AllArgsConstructor
 public class CommentReviewDiffService {
-    private final ReviewRepository reviewRepository;
     private final CommentReviewDiffRepository commentReviewDiffRepository;
     private final DiscussionCodeRepository discussionCodeRepository;
 
-    public Review saveCommentReviewDiff(CreateCommentReviewRequestDto dto, Review review) {
-        List<CommentReviewDiffDto> list = dto.diffList;
-        for(CommentReviewDiffDto item : list) {
-            DiscussionCode code = discussionCodeRepository
-                    .findByIdFetchJoin(item.getDiscussionCode().getId())
-                    .orElseThrow(() -> new NoSuchElementException("discussionCodeId가 없습니다."));
-            CommentReviewDiff commentReviewDiff = CommentReviewDiffDto.toEntity(item, review, code);
-            commentReviewDiff.setReview(review);
-            commentReviewDiffRepository.save(commentReviewDiff);
-        }
-        return review;
+    public List<CommentReviewDiff> createCommentReviewDiff(Review review, List<CommentReviewDiffDto> list) {
+        List<CommentReviewDiff> diffList = null;
+        List<Long> idList = null;
+        for(int i = 0; i < list.size(); i++)
+            idList.add(list.get(i).getDiscussionCode().getId());
+        List<DiscussionCode> codeList = discussionCodeRepository.findByIdListFetchJoin(idList);
+        for(int i = 0; i < list.size(); i++)
+            diffList.add(CommentReviewDiffDto.toEntity(list.get(i), review, codeList.get(i)));
+        commentReviewDiffRepository.saveAll(diffList);
+        return diffList;
     }
 }

--- a/src/main/java/com/hidiscuss/backend/service/CommentReviewDiffService.java
+++ b/src/main/java/com/hidiscuss/backend/service/CommentReviewDiffService.java
@@ -24,9 +24,11 @@ public class CommentReviewDiffService {
         List<CommentReviewDiffDto> list = dto.getDiffList();
         List<CommentReviewDiff> diffList = new ArrayList<>();
         List<Long> idList = new ArrayList<>();
+
         for (int i = 0; i < list.size(); i++)
             idList.add(list.get(i).getDiscussionCode().getId());
         List<DiscussionCode> codeList = discussionCodeRepository.findByIdListFetch(idList);
+
         if (codeList.size() != 0) {
             for (int i = 0; i < list.size(); i++) {
                 for (int j = 0; j < codeList.size(); j++) {

--- a/src/main/java/com/hidiscuss/backend/service/CommentReviewDiffService.java
+++ b/src/main/java/com/hidiscuss/backend/service/CommentReviewDiffService.java
@@ -25,7 +25,7 @@ public class CommentReviewDiffService {
         List<CommentReviewDiffDto> list = dto.diffList;
         for(CommentReviewDiffDto item : list) {
             DiscussionCode code = discussionCodeRepository
-                    .findById(item.getDiscussionCode().getId())
+                    .findByIdFetchJoin(item.getDiscussionCode().getId())
                     .orElseThrow(() -> new NoSuchElementException("discussionCodeId가 없습니다."));
             CommentReviewDiff commentReviewDiff = CommentReviewDiffDto.toEntity(item, review, code);
             commentReviewDiff.setReview(review);

--- a/src/main/java/com/hidiscuss/backend/service/CommentReviewDiffService.java
+++ b/src/main/java/com/hidiscuss/backend/service/CommentReviewDiffService.java
@@ -1,14 +1,17 @@
 package com.hidiscuss.backend.service;
 
 import com.hidiscuss.backend.controller.dto.CommentReviewDiffDto;
+import com.hidiscuss.backend.controller.dto.CreateCommentReviewRequestDto;
 import com.hidiscuss.backend.entity.CommentReviewDiff;
 import com.hidiscuss.backend.entity.DiscussionCode;
 import com.hidiscuss.backend.entity.Review;
+import com.hidiscuss.backend.exception.EmptyDiscussionCodeException;
 import com.hidiscuss.backend.repository.CommentReviewDiffRepository;
 import com.hidiscuss.backend.repository.DiscussionCodeRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -17,15 +20,33 @@ public class CommentReviewDiffService {
     private final CommentReviewDiffRepository commentReviewDiffRepository;
     private final DiscussionCodeRepository discussionCodeRepository;
 
-    public List<CommentReviewDiff> createCommentReviewDiff(Review review, List<CommentReviewDiffDto> list) {
-        List<CommentReviewDiff> diffList = null;
-        List<Long> idList = null;
-        for(int i = 0; i < list.size(); i++)
+    public List<CommentReviewDiff> createCommentReviewDiff(Review review, CreateCommentReviewRequestDto dto) {
+        List<CommentReviewDiffDto> list = dto.getDiffList();
+        List<CommentReviewDiff> diffList = new ArrayList<>();
+        List<Long> idList = new ArrayList<>();
+        for (int i = 0; i < list.size(); i++)
             idList.add(list.get(i).getDiscussionCode().getId());
-        List<DiscussionCode> codeList = discussionCodeRepository.findByIdListFetchJoin(idList);
-        for(int i = 0; i < list.size(); i++)
-            diffList.add(CommentReviewDiffDto.toEntity(list.get(i), review, codeList.get(i)));
-        commentReviewDiffRepository.saveAll(diffList);
-        return diffList;
+        List<DiscussionCode> codeList = discussionCodeRepository.findByIdListFetch(idList);
+        if (codeList.size() != 0) {
+            for (int i = 0; i < list.size(); i++) {
+                for (int j = 0; j < codeList.size(); j++) {
+                    if (list.get(i).getDiscussionCode().getId() == codeList.get(j).getId()) {
+                        CommentReviewDiffDto tmpDto = list.get(i);
+                        diffList.add(
+                                CommentReviewDiff.builder()
+                                        .review(review)
+                                        .discussionCode(codeList.get(j))
+                                        .codeAfter(tmpDto.getCodeAfter())
+                                        .codeLocate(tmpDto.getCodeLocate())
+                                        .comment(tmpDto.getComment())
+                                        .build());
+                        break;
+                    }
+                }
+            }
+        }
+        if (dto.getDiffList().size() != diffList.size() || codeList.size() == 0)
+            throw new EmptyDiscussionCodeException("Some discussion code is missing");
+        return commentReviewDiffRepository.saveAll(diffList);
     }
 }

--- a/src/main/java/com/hidiscuss/backend/service/ReviewService.java
+++ b/src/main/java/com/hidiscuss/backend/service/ReviewService.java
@@ -55,7 +55,6 @@ public class ReviewService {
         return reviewThread;
     }
 
-    //fetch 필요한지 확인 후 테스트코드 작성
     public Review findByIdFetchOrNull(Long id) {
         Review review = reviewRepository.findByIdFetchOrNull(id);
         if (review == null) throw new NoSuchElementException("Review not found");

--- a/src/main/java/com/hidiscuss/backend/service/ReviewService.java
+++ b/src/main/java/com/hidiscuss/backend/service/ReviewService.java
@@ -21,7 +21,7 @@ public class ReviewService {
 
     public Review saveReview(User user, CreateCommentReviewRequestDto dto, ReviewType reviewType) {
         Discussion discussion = discussionRepository
-                .findById(dto.discussionId)
+                .findByIdFetchJoin(dto.discussionId)
                 .orElseThrow(() -> new NoSuchElementException("discussionId가 없습니다."));
         Review review = Review.builder()
                 .reviewer(user)
@@ -36,7 +36,7 @@ public class ReviewService {
 
     public ReviewThread saveThread(User user, CreateThreadRequestDto dto, Long reviewId) {
         Review review = reviewRepository
-                .findById(reviewId)
+                .findByIdFetchJoin(reviewId)
                 .orElseThrow(() -> new NoSuchElementException("reviewId가 없습니다."));
         ReviewThread reviewThread = ReviewThread.builder()
                 .user(user)

--- a/src/main/resources/config/db/application.yml
+++ b/src/main/resources/config/db/application.yml
@@ -8,6 +8,14 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      # ddl-auto: none
       ddl-auto: create
     generate-ddl: true
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+    defer-datasource-initialization: true
+  sql:
+    init:
+      mode: always
+      continue-on-error: true

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,15 @@
+-- user(id 7000) 생성
+INSERT INTO `hidiscuss`.`user` (`id`, `created_at`, `last_modified_at`, `access_token`, `email`, `username`, `point`, `refresh_token`) VALUES (7000, NOW(), NOW(), '1', '1', '1', 1, '1');
+
+-- discussion(id 7100) 생성
+INSERT INTO `hidiscuss`.`discussion` (`id`, `created_at`, `last_modified_at`, `live_review_required`, `priority`, `question`, `state`, `user_id`) VALUES (7100, NOW(), NOW(), 0, 0, '0', 'NOT_REVIEWED', 7000);
+
+-- discussionCode(id 7200, 7201) 생성
+INSERT INTO `hidiscuss`.`discussion_code` (`id`, `created_at`, `last_modified_at`, `additions`, `changes`, `content`, `deletions`, `filename`, `sha`, `status`, `discussion_id`) VALUES (7200, NOW(), NOW(), 1, 1, '1', 1, '1', '1', 'ADDED', 7100);
+INSERT INTO `hidiscuss`.`discussion_code` (`id`, `created_at`, `last_modified_at`, `additions`, `changes`, `content`, `deletions`, `filename`, `sha`, `status`, `discussion_id`) VALUES (7201, NOW(), NOW(), 1, 1, '1', 1, '1', '1', 'ADDED', 7100);
+
+-- review(id 7300) 생성
+-- INSERT INTO `hidiscuss`.`review` (`id`, `created_at`, `last_modified_at`, `accepted`, `review_type`, `discussion_id`, `reviewer_id`) VALUES (7300, NOW(), NOW(), 0, '0', 7100, 7000);
+
+
+

--- a/src/test/java/com/hidiscuss/backend/service/CommentReviewDiffServiceTest.java
+++ b/src/test/java/com/hidiscuss/backend/service/CommentReviewDiffServiceTest.java
@@ -17,7 +17,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.NoSuchElementException;
 
 import static org.assertj.core.api.BDDAssertions.catchThrowable;
 import static org.assertj.core.api.BDDAssertions.then;
@@ -27,9 +26,12 @@ import static org.mockito.BDDMockito.given;
 @ExtendWith(MockitoExtension.class)
 public class CommentReviewDiffServiceTest {
 
-    @Mock private CommentReviewDiffRepository commentReviewDiffRepository;
-    @Mock private DiscussionCodeRepository discussionCodeRepository;
-    @InjectMocks private CommentReviewDiffService commentReviewDiffService;
+    @Mock
+    private CommentReviewDiffRepository commentReviewDiffRepository;
+    @Mock
+    private DiscussionCodeRepository discussionCodeRepository;
+    @InjectMocks
+    private CommentReviewDiffService commentReviewDiffService;
 
     private User user;
     private Review review;

--- a/src/test/java/com/hidiscuss/backend/service/CommentReviewDiffServiceTest.java
+++ b/src/test/java/com/hidiscuss/backend/service/CommentReviewDiffServiceTest.java
@@ -68,8 +68,8 @@ public class CommentReviewDiffServiceTest {
     void saveCommentReviewDiff_common() {
         CreateCommentReviewRequestDto dto = new CreateCommentReviewRequestDto(1L, diffList);
 
-        given(discussionCodeRepository.findById(discussionCode_1.getId())).willReturn(Optional.of(discussionCode_1));
-        given(discussionCodeRepository.findById(discussionCode_2.getId())).willReturn(Optional.of(discussionCode_2));
+        given(discussionCodeRepository.findByIdFetchJoin(discussionCode_1.getId())).willReturn(Optional.of(discussionCode_1));
+        given(discussionCodeRepository.findByIdFetchJoin(discussionCode_2.getId())).willReturn(Optional.of(discussionCode_2));
         given(commentReviewDiffRepository.save(any(CommentReviewDiff.class))).willAnswer(i -> i.getArgument(0));
 
         review = commentReviewDiffService.saveCommentReviewDiff(dto, review);
@@ -84,7 +84,7 @@ public class CommentReviewDiffServiceTest {
     void saveCommentReviewDiff_withNoDiscussionCode() {
         CreateCommentReviewRequestDto dto = new CreateCommentReviewRequestDto(1L, diffList);
         Review review = new Review();
-        given(discussionCodeRepository.findById(any(Long.class))).willReturn(Optional.empty());
+        given(discussionCodeRepository.findByIdFetchJoin(any(Long.class))).willReturn(Optional.empty());
 
         Throwable throwable = catchThrowable(() -> commentReviewDiffService.saveCommentReviewDiff(dto, review));
 

--- a/src/test/java/com/hidiscuss/backend/service/CommentReviewDiffServiceTest.java
+++ b/src/test/java/com/hidiscuss/backend/service/CommentReviewDiffServiceTest.java
@@ -1,0 +1,98 @@
+package com.hidiscuss.backend.service;
+
+import com.hidiscuss.backend.controller.dto.CommentReviewDiffDto;
+import com.hidiscuss.backend.controller.dto.CommentReviewResponseDto;
+import com.hidiscuss.backend.controller.dto.CreateCommentReviewRequestDto;
+import com.hidiscuss.backend.controller.dto.DiscussionCodeDto;
+import com.hidiscuss.backend.entity.*;
+import com.hidiscuss.backend.repository.CommentReviewDiffRepository;
+import com.hidiscuss.backend.repository.DiscussionCodeRepository;
+import com.hidiscuss.backend.repository.ReviewRepository;
+import com.hidiscuss.backend.repository.ReviewThreadRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static org.assertj.core.api.BDDAssertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class CommentReviewDiffServiceTest {
+
+    @Mock private CommentReviewDiffRepository commentReviewDiffRepository;
+    @Mock private DiscussionCodeRepository discussionCodeRepository;
+    @InjectMocks private CommentReviewDiffService commentReviewDiffService;
+
+    private User user;
+
+    private ReviewType reviewType = ReviewType.COMMENT;
+
+    private List<CommentReviewDiffDto> diffList;
+
+    private List<CommentReviewDiff> entityList;
+
+    private Review review;
+
+    private DiscussionCode discussionCode_1;
+    private DiscussionCode discussionCode_2;
+
+    @BeforeEach
+    void setUp() {
+        user = new User();
+        review = Review.builder().id(1L).diffList(new ArrayList<>()).build();
+        discussionCode_1 = DiscussionCode.builder().id(1L).build();
+        discussionCode_2 = DiscussionCode.builder().id(2L).build();
+        diffList = List.of(
+                getCommentReviewDiffDto(discussionCode_1),
+                getCommentReviewDiffDto(discussionCode_2)
+        );
+        entityList = List.of(
+                CommentReviewDiffDto.toEntity(diffList.get(0), review, discussionCode_1),
+                CommentReviewDiffDto.toEntity(diffList.get(1), review, discussionCode_2)
+        );
+    }
+
+    @Test
+    @DisplayName("saveCommentReviewDiff_commentReviewDiff가 저장된다.")
+    void saveCommentReviewDiff_common() {
+        CreateCommentReviewRequestDto dto = new CreateCommentReviewRequestDto(1L, diffList);
+
+        given(discussionCodeRepository.findById(discussionCode_1.getId())).willReturn(Optional.of(discussionCode_1));
+        given(discussionCodeRepository.findById(discussionCode_2.getId())).willReturn(Optional.of(discussionCode_2));
+        given(commentReviewDiffRepository.save(any(CommentReviewDiff.class))).willAnswer(i -> i.getArgument(0));
+
+        review = commentReviewDiffService.saveCommentReviewDiff(dto, review);
+
+        then(CommentReviewDiffDto.fromEntity(review.getDiffList().get(0)).getDiscussionCode().getId()).isEqualTo(diffList.get(0).getDiscussionCode().getId());
+        then(CommentReviewDiffDto.fromEntity(review.getDiffList().get(1)).getDiscussionCode().getId()).isEqualTo(diffList.get(1).getDiscussionCode().getId());
+        then(review.getDiffList().size()).isEqualTo(diffList.size());
+    }
+
+    @Test
+    @DisplayName("saveCommentReviewDiff_discussionCode가 없을 경우 예외를 반환한다.")
+    void saveCommentReviewDiff_withNoDiscussionCode() {
+        CreateCommentReviewRequestDto dto = new CreateCommentReviewRequestDto(1L, diffList);
+        Review review = new Review();
+        given(discussionCodeRepository.findById(any(Long.class))).willReturn(Optional.empty());
+
+        Throwable throwable = catchThrowable(() -> commentReviewDiffService.saveCommentReviewDiff(dto, review));
+
+        then(throwable).isInstanceOf(NoSuchElementException.class);
+    }
+
+    private CommentReviewDiffDto getCommentReviewDiffDto(DiscussionCode discussionCode) {
+        DiscussionCodeDto dto = DiscussionCodeDto.fromEntity(discussionCode);
+        return new CommentReviewDiffDto(dto, "codeAfter", "codeLocate", "comment");
+    }
+}

--- a/src/test/java/com/hidiscuss/backend/service/CommentReviewDiffServiceTest.java
+++ b/src/test/java/com/hidiscuss/backend/service/CommentReviewDiffServiceTest.java
@@ -1,14 +1,12 @@
 package com.hidiscuss.backend.service;
 
 import com.hidiscuss.backend.controller.dto.CommentReviewDiffDto;
-import com.hidiscuss.backend.controller.dto.CommentReviewResponseDto;
 import com.hidiscuss.backend.controller.dto.CreateCommentReviewRequestDto;
 import com.hidiscuss.backend.controller.dto.DiscussionCodeDto;
 import com.hidiscuss.backend.entity.*;
+import com.hidiscuss.backend.exception.EmptyDiscussionCodeException;
 import com.hidiscuss.backend.repository.CommentReviewDiffRepository;
 import com.hidiscuss.backend.repository.DiscussionCodeRepository;
-import com.hidiscuss.backend.repository.ReviewRepository;
-import com.hidiscuss.backend.repository.ReviewThreadRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,11 +18,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 
 import static org.assertj.core.api.BDDAssertions.catchThrowable;
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -35,60 +32,60 @@ public class CommentReviewDiffServiceTest {
     @InjectMocks private CommentReviewDiffService commentReviewDiffService;
 
     private User user;
-
+    private Review review;
     private ReviewType reviewType = ReviewType.COMMENT;
 
-    private List<CommentReviewDiffDto> diffList;
-
-    private List<CommentReviewDiff> entityList;
-
-    private Review review;
+    private List<CommentReviewDiffDto> dtoList;
+    private List<DiscussionCode> codeList;
+    private List<Long> idList;
 
     private DiscussionCode discussionCode_1;
     private DiscussionCode discussionCode_2;
+    private CreateCommentReviewRequestDto dto;
 
     @BeforeEach
     void setUp() {
         user = new User();
-        review = Review.builder().id(1L).diffList(new ArrayList<>()).build();
+        review = Review.builder().id(1L).commentDiffList(new ArrayList<>()).build();
         discussionCode_1 = DiscussionCode.builder().id(1L).build();
         discussionCode_2 = DiscussionCode.builder().id(2L).build();
-        diffList = List.of(
+        dtoList = List.of(
                 getCommentReviewDiffDto(discussionCode_1),
                 getCommentReviewDiffDto(discussionCode_2)
         );
-        entityList = List.of(
-                CommentReviewDiffDto.toEntity(diffList.get(0), review, discussionCode_1),
-                CommentReviewDiffDto.toEntity(diffList.get(1), review, discussionCode_2)
+        codeList = List.of(
+                discussionCode_1,
+                discussionCode_2
         );
+        idList = List.of(
+                discussionCode_1.getId(),
+                discussionCode_2.getId()
+        );
+        dto = new CreateCommentReviewRequestDto(1L, dtoList);
     }
 
     @Test
     @DisplayName("saveCommentReviewDiff_commentReviewDiff가 저장된다.")
     void saveCommentReviewDiff_common() {
-        CreateCommentReviewRequestDto dto = new CreateCommentReviewRequestDto(1L, diffList);
+        given(discussionCodeRepository.findByIdListFetch(idList)).willReturn(codeList);
+        given(commentReviewDiffRepository.saveAll(anyList())).willAnswer(i -> i.getArgument(0));
 
-        given(discussionCodeRepository.findByIdFetchJoin(discussionCode_1.getId())).willReturn(Optional.of(discussionCode_1));
-        given(discussionCodeRepository.findByIdFetchJoin(discussionCode_2.getId())).willReturn(Optional.of(discussionCode_2));
-        given(commentReviewDiffRepository.save(any(CommentReviewDiff.class))).willAnswer(i -> i.getArgument(0));
+        List<CommentReviewDiff> entityList = commentReviewDiffService.createCommentReviewDiff(review, dto);
 
-        review = commentReviewDiffService.saveCommentReviewDiff(dto, review);
-
-        then(CommentReviewDiffDto.fromEntity(review.getDiffList().get(0)).getDiscussionCode().getId()).isEqualTo(diffList.get(0).getDiscussionCode().getId());
-        then(CommentReviewDiffDto.fromEntity(review.getDiffList().get(1)).getDiscussionCode().getId()).isEqualTo(diffList.get(1).getDiscussionCode().getId());
-        then(review.getDiffList().size()).isEqualTo(diffList.size());
+        then(entityList.get(0).getDiscussionCode().getId()).isEqualTo(discussionCode_1.getId());
+        then(entityList.get(1).getDiscussionCode().getId()).isEqualTo(discussionCode_2.getId());
+        then(entityList.size()).isEqualTo(dto.getDiffList().size());
     }
 
     @Test
-    @DisplayName("saveCommentReviewDiff_discussionCode가 없을 경우 예외를 반환한다.")
+    @DisplayName("saveCommentReviewDiff_discussionCode 개수만큼 만들어지지 않은 경우 예외를 반환한다.")
     void saveCommentReviewDiff_withNoDiscussionCode() {
-        CreateCommentReviewRequestDto dto = new CreateCommentReviewRequestDto(1L, diffList);
         Review review = new Review();
-        given(discussionCodeRepository.findByIdFetchJoin(any(Long.class))).willReturn(Optional.empty());
+        given(discussionCodeRepository.findByIdListFetch(idList)).willReturn(new ArrayList<>());
 
-        Throwable throwable = catchThrowable(() -> commentReviewDiffService.saveCommentReviewDiff(dto, review));
+        Throwable throwable = catchThrowable(() -> commentReviewDiffService.createCommentReviewDiff(review, dto));
 
-        then(throwable).isInstanceOf(NoSuchElementException.class);
+        then(throwable).isInstanceOf(EmptyDiscussionCodeException.class);
     }
 
     private CommentReviewDiffDto getCommentReviewDiffDto(DiscussionCode discussionCode) {

--- a/src/test/java/com/hidiscuss/backend/service/ReviewServiceTest.java
+++ b/src/test/java/com/hidiscuss/backend/service/ReviewServiceTest.java
@@ -24,10 +24,14 @@ import static org.mockito.Mockito.mock;
 @ExtendWith(MockitoExtension.class)
 public class ReviewServiceTest {
 
-    @Mock private ReviewRepository reviewRepository;
-    @Mock private DiscussionRepository discussionRepository;
-    @Mock private ReviewThreadRepository reviewThreadRepository;
-    @InjectMocks private ReviewService reviewService;
+    @Mock
+    private ReviewRepository reviewRepository;
+    @Mock
+    private DiscussionRepository discussionRepository;
+    @Mock
+    private ReviewThreadRepository reviewThreadRepository;
+    @InjectMocks
+    private ReviewService reviewService;
 
     private User user;
 

--- a/src/test/java/com/hidiscuss/backend/service/ReviewServiceTest.java
+++ b/src/test/java/com/hidiscuss/backend/service/ReviewServiceTest.java
@@ -25,15 +25,8 @@ import static org.mockito.BDDMockito.given;
 public class ReviewServiceTest {
 
     @Mock private ReviewRepository reviewRepository;
-
     @Mock private DiscussionRepository discussionRepository;
-
-    @Mock private CommentReviewDiffRepository commentReviewDiffRepository;
-
-    @Mock private DiscussionCodeRepository discussionCodeRepository;
-
     @Mock private ReviewThreadRepository reviewThreadRepository;
-
     @InjectMocks private ReviewService reviewService;
 
     private User user;
@@ -79,41 +72,12 @@ public class ReviewServiceTest {
     }
 
     @Test
-    @DisplayName("saveCommentReviewDiff_commentReviewDiff가 저장된다.")
-    void saveCommentReviewDiff_common() {
-        CreateCommentReviewRequestDto dto = new CreateCommentReviewRequestDto(1L, diffList);
-        DiscussionCode discussionCode = new DiscussionCode();
-        Review review = new Review();
-        given(discussionCodeRepository.findById(any(Long.class))).willReturn(Optional.of(discussionCode));
-        given(commentReviewDiffRepository.save(any(CommentReviewDiff.class))).willAnswer(i -> i.getArgument(0));
-        given(reviewRepository.findById(any(Long.class))).willAnswer(i -> i.getArgument(0));
-
-        review = reviewService.saveCommentReviewDiff(dto, review);
-
-        then(review.getDiffList()).isEqualTo(diffList);
-        then(review.getDiffList().size()).isEqualTo(diffList.size());
-    }
-
-    @Test
-    @DisplayName("saveCommentReviewDiff_discussionCode가 없을 경우 예외를 반환한다.")
-    void saveCommentReviewDiff_withNoDiscussionCode() {
-        CreateCommentReviewRequestDto dto = new CreateCommentReviewRequestDto(1L, diffList);
-        DiscussionCode discussionCode = new DiscussionCode();
-        Review review = new Review();
-        given(discussionCodeRepository.findById(any(Long.class))).willReturn(Optional.empty());
-
-        Throwable throwable = catchThrowable(() -> reviewService.saveCommentReviewDiff(dto, review));
-
-        then(throwable).isInstanceOf(NoSuchElementException.class);
-
-    }
-
-    @Test
     @DisplayName("saveThread_thread가 저장된다")
     void saveThread_common() {
         CreateThreadRequestDto dto = new CreateThreadRequestDto("comment");
         Review review = Review.builder().id(1L).build();
         given(reviewRepository.findById(any(Long.class))).willReturn(Optional.ofNullable(review));
+        given(reviewThreadRepository.save(any(ReviewThread.class))).willAnswer(i -> i.getArgument(0));
 
         ReviewThread reviewThread = reviewService.saveThread(user, dto, 1L);
 

--- a/src/test/java/com/hidiscuss/backend/service/ReviewServiceTest.java
+++ b/src/test/java/com/hidiscuss/backend/service/ReviewServiceTest.java
@@ -76,7 +76,7 @@ public class ReviewServiceTest {
     void saveThread_common() {
         CreateThreadRequestDto dto = new CreateThreadRequestDto("comment");
         Review review = Review.builder().id(1L).build();
-        given(reviewRepository.findById(any(Long.class))).willReturn(Optional.ofNullable(review));
+        given(reviewRepository.findByIdFetchJoin(any(Long.class))).willReturn(Optional.ofNullable(review));
         given(reviewThreadRepository.save(any(ReviewThread.class))).willAnswer(i -> i.getArgument(0));
 
         ReviewThread reviewThread = reviewService.saveThread(user, dto, 1L);

--- a/src/test/java/com/hidiscuss/backend/service/ReviewServiceTest.java
+++ b/src/test/java/com/hidiscuss/backend/service/ReviewServiceTest.java
@@ -49,7 +49,7 @@ public class ReviewServiceTest {
     void saveReview_common() {
         CreateCommentReviewRequestDto dto = new CreateCommentReviewRequestDto(1L, diffList);
         Discussion discussion = new Discussion();
-        given(discussionRepository.findById(any(Long.class))).willReturn(Optional.of(discussion));
+        given(discussionRepository.findByIdFetchJoin(any(Long.class))).willReturn(Optional.of(discussion));
         given(reviewRepository.save(any(Review.class))).willAnswer(i -> i.getArgument(0));
 
         Review review = reviewService.saveReview(user, dto, reviewType);
@@ -64,7 +64,7 @@ public class ReviewServiceTest {
     @DisplayName("saveReview_discussion이 없을 경우 예외를 반환한다.")
     void saveReview_withNoDiscussion() {
         CreateCommentReviewRequestDto dto = new CreateCommentReviewRequestDto(1L, diffList);
-        given(discussionRepository.findById(any(Long.class))).willReturn(Optional.empty());
+        given(discussionRepository.findByIdFetchJoin(any(Long.class))).willReturn(Optional.empty());
 
         Throwable throwable = catchThrowable(() -> reviewService.saveReview(user, dto, reviewType));
 


### PR DESCRIPTION
## 티켓
[CAPS-112](https://2022springcapstone.atlassian.net/browse/CAPS-112)
[CAPS-113](https://2022springcapstone.atlassian.net/browse/CAPS-113)

## 작업내용
- 컨트롤러에서 두 개 서비스 메서드를 호출했는데, 하나의 서비스로 묶어서 `@Transaction` 적용
- `ReviewService` 중 책임이 다른 메서드를 `CommentReviewDiffService`로 분리
-  `CommentReviewDiffServiceTest`, `ReviewServiceTest` 테스트 코드 보완
-  `Discussion`, `DiscussionCode`, `Review`  등 메서드에 연관관계가 연결된 엔티티가 프록시 객체일 수 있으므로 fetchjoin으로 한 쿼리에 가져오도록 설정

## 논의사항
다들 fk 제약조건에 걸릴 때 테스트를 어떻게 진행하시나요? data.sql 사용해서 데이터베이스 init 후에 데이터 넣게 하고 있는데 다른분들은 어떻게 사용하시는지 궁금합니다!
[참고한 스프링 문서](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto.data-initialization.using-basic-sql-scripts)