### PR TITLE
CAPS 126 / 라이브리뷰 예약 서비스

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ backend for capstone-signal project
 - `jibDockerBuild` : build the project with jib ( Local Docker Image Build )
 - `jib`: build the project with jib & push to ECR
 
+### Required Environment Variables
+- `EMAIL_USERNAME` : email username
+- `EMAIL_PASSWORD` : email password for smtp server
+
 
 ### ERD
 ![entity relation](https://user-images.githubusercontent.com/43488326/163690749-8d74ecd2-ff62-448d-8ea8-4814ab2a9d54.png)

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'mysql:mysql-connector-java'
@@ -46,6 +47,9 @@ dependencies {
   
 	// Github REST API Client
 	implementation 'org.kohsuke:github-api:1.303'
+
+	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hidiscuss/backend/config/MailSenderConfig.java
+++ b/src/main/java/com/hidiscuss/backend/config/MailSenderConfig.java
@@ -1,0 +1,35 @@
+package com.hidiscuss.backend.config;
+
+import com.hidiscuss.backend.utils.MailSenderProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+@RequiredArgsConstructor
+public class MailSenderConfig {
+
+    private final MailSenderProperties mailSenderProperties;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(mailSenderProperties.getHost());
+        mailSender.setPort(mailSenderProperties.getPort());
+
+        mailSender.setUsername(mailSenderProperties.getUsername());
+        mailSender.setPassword(mailSenderProperties.getPassword());
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.auth", mailSenderProperties.getPropertiesMailSmtpAuth());
+        props.put("mail.smtp.starttls.enable", mailSenderProperties.getPropertiesMailSmtpStarttlsEnable());
+
+        return mailSender;
+
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/controller/dto/CreateReviewReservationRequestDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/CreateReviewReservationRequestDto.java
@@ -12,5 +12,6 @@ public class CreateReviewReservationRequestDto {
 
     @NotNull
     @Future
-    public LocalDateTime reviewDate;
+    public LocalDateTime reviewStartDateTime;
+
 }

--- a/src/main/java/com/hidiscuss/backend/controller/dto/ReviewReservationResponseDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/ReviewReservationResponseDto.java
@@ -12,15 +12,15 @@ public class ReviewReservationResponseDto {
     //private UserResponseDto user;
     //private ReviewResponseDto review;
     private DiscussionResponseDto discussion;
-    private LocalDateTime reviewDate;
+    private LocalDateTime reviewStartDateTime;
     private Boolean reviewerParticipated;
     private Boolean revieweeParticipated;
     private Boolean isdone;
 
-    private ReviewReservationResponseDto(Long id, DiscussionResponseDto discussion, LocalDateTime reviewDate, Boolean reviewerParticipated, Boolean revieweeParticipated, Boolean isdone) {
+    private ReviewReservationResponseDto(Long id, DiscussionResponseDto discussion, LocalDateTime reviewStartDateTime, Boolean reviewerParticipated, Boolean revieweeParticipated, Boolean isdone) {
         this.id = id;
         this.discussion = discussion;
-        this.reviewDate = reviewDate;
+        this.reviewStartDateTime = reviewStartDateTime;
         this.reviewerParticipated = reviewerParticipated;
         this.revieweeParticipated = revieweeParticipated;
         this.isdone = isdone;
@@ -32,7 +32,7 @@ public class ReviewReservationResponseDto {
         return new ReviewReservationResponseDto(
                 reviewReservation.getId(),
                 DiscussionResponseDto.fromEntity(reviewReservation.getDiscussion()),
-                reviewReservation.getReviewDate(),
+                reviewReservation.getReviewStartDateTime(),
                 reviewReservation.getReviewerParticipated(),
                 reviewReservation.getRevieweeParticipated(),
                 reviewReservation.getIsdone()

--- a/src/main/java/com/hidiscuss/backend/controller/dto/SendEmailDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/SendEmailDto.java
@@ -1,0 +1,31 @@
+package com.hidiscuss.backend.controller.dto;
+
+import lombok.AllArgsConstructor;
+import org.springframework.mail.MailMessage;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.MimeMailMessage;
+import org.springframework.mail.javamail.MimeMessageHelper;
+
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotNull;
+
+@AllArgsConstructor
+public class SendEmailDto {
+    @Email
+    private String to;
+
+    @NotNull
+    private String subject;
+
+    @NotNull
+    private String text;
+
+    public void applyHelper(MimeMessageHelper mimeMessageHelper) throws MessagingException {
+        mimeMessageHelper.setTo(to);
+        mimeMessageHelper.setSubject(subject);
+        mimeMessageHelper.setText(text, true); // TODO debug.. encoding
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/entity/Discussion.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Discussion.java
@@ -41,7 +41,8 @@ public class Discussion extends BaseEntity {
     private Long priority;
 
     @Builder
-    public Discussion(User user, String question, String title, Boolean liveReviewRequired, LiveReviewAvailableTimes liveReviewAvailableTimes, Long priority) {
+    public Discussion(Long id, User user, String question, String title, Boolean liveReviewRequired, LiveReviewAvailableTimes liveReviewAvailableTimes, Long priority) {
+        this.id = id;
         this.state = DiscussionState.NOT_REVIEWED;
         this.user = user;
         this.title = title;

--- a/src/main/java/com/hidiscuss/backend/entity/LiveReviewAvailableTimes.java
+++ b/src/main/java/com/hidiscuss/backend/entity/LiveReviewAvailableTimes.java
@@ -1,17 +1,52 @@
 package com.hidiscuss.backend.entity;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 
 @Getter
+@NoArgsConstructor
 public class LiveReviewAvailableTimes {
     private List<LiveReviewAvailableTime> times;
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LiveReviewAvailableTimes that = (LiveReviewAvailableTimes) o;
+        return times.equals(that.times);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(times);
+    }
+
+    public LiveReviewAvailableTimes(List<LiveReviewAvailableTime> times) {
+        this.times = times;
+    }
+
     @Getter
-    private static class LiveReviewAvailableTime {
+    @Setter
+    public static class LiveReviewAvailableTime {
         private LocalDateTime start;
         private LocalDateTime end;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            LiveReviewAvailableTime that = (LiveReviewAvailableTime) o;
+            return Objects.equals(start, that.start) && Objects.equals(end, that.end);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(start, end);
+        }
     }
 }

--- a/src/main/java/com/hidiscuss/backend/entity/LiveReviewAvailableTimesConverter.java
+++ b/src/main/java/com/hidiscuss/backend/entity/LiveReviewAvailableTimesConverter.java
@@ -2,16 +2,23 @@ package com.hidiscuss.backend.entity;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
 import javax.persistence.AttributeConverter;
 import javax.persistence.Converter;
 
 @Converter
+@Slf4j
+@Component
+@RequiredArgsConstructor
 public class LiveReviewAvailableTimesConverter implements AttributeConverter<LiveReviewAvailableTimes, String> {
-    private static final Logger logger = LoggerFactory.getLogger(LiveReviewAvailableTimesConverter.class);
-    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final ObjectMapper objectMapper;
+
     @Override
     public String convertToDatabaseColumn(LiveReviewAvailableTimes attribute) {
         String stringified = null;
@@ -21,7 +28,7 @@ public class LiveReviewAvailableTimesConverter implements AttributeConverter<Liv
         try {
             stringified = objectMapper.writeValueAsString(attribute);
         } catch (JsonProcessingException e) {
-            logger.error("Convert error", e);
+            log.error("Convert error", e);
             throw new RuntimeException(e); // TODO : change to custom exception
         }
         return stringified;
@@ -36,7 +43,7 @@ public class LiveReviewAvailableTimesConverter implements AttributeConverter<Liv
         try {
             attribute = objectMapper.readValue(dbData, LiveReviewAvailableTimes.class);
         } catch (JsonProcessingException e) {
-            logger.error("Convert error", e);
+            log.error("Convert error", e);
             throw new RuntimeException(e); // TODO : change to custom exception
         }
         return attribute;

--- a/src/main/java/com/hidiscuss/backend/entity/ReviewReservation.java
+++ b/src/main/java/com/hidiscuss/backend/entity/ReviewReservation.java
@@ -29,8 +29,8 @@ public class ReviewReservation extends BaseEntity {
     @JoinColumn(name = "discussion_id", nullable = false)
     private Discussion discussion;
 
-    @Column(name = "review_date", nullable = false)
-    private LocalDateTime reviewDate;
+    @Column(name = "review_start_date", nullable = false)
+    private LocalDateTime reviewStartDateTime;
 
     @Column(columnDefinition ="boolean default false", name = "reviewer_participated", nullable = false)
     private Boolean reviewerParticipated;
@@ -42,14 +42,14 @@ public class ReviewReservation extends BaseEntity {
     private Boolean isdone;
 
     @Builder
-    public ReviewReservation(Long id, User reviewer, Review review, Discussion discussion, LocalDateTime reviewDate, Boolean reviewerParticipated, Boolean revieweeParticipated, Boolean isdone) {
+    public ReviewReservation(Long id, User reviewer, Review review, Discussion discussion, LocalDateTime reviewStartDateTime) {
         this.id = id;
         this.reviewer = reviewer;
         this.review = review;
         this.discussion = discussion;
-        this.reviewDate = reviewDate;
-        this.reviewerParticipated = reviewerParticipated;
-        this.revieweeParticipated = revieweeParticipated;
-        this.isdone = isdone;
+        this.reviewStartDateTime = reviewStartDateTime;
+        this.reviewerParticipated = false;
+        this.revieweeParticipated = false;
+        this.isdone = false;
     }
 }

--- a/src/main/java/com/hidiscuss/backend/repository/ReviewReservationRepository.java
+++ b/src/main/java/com/hidiscuss/backend/repository/ReviewReservationRepository.java
@@ -3,5 +3,8 @@ package com.hidiscuss.backend.repository;
 import com.hidiscuss.backend.entity.ReviewReservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ReviewReservationRepository extends JpaRepository<ReviewReservation, Long>, ReviewReservationRepositoryCustom {
+
 }

--- a/src/main/java/com/hidiscuss/backend/repository/ReviewReservationRepositoryCustom.java
+++ b/src/main/java/com/hidiscuss/backend/repository/ReviewReservationRepositoryCustom.java
@@ -1,4 +1,9 @@
 package com.hidiscuss.backend.repository;
 
+import com.hidiscuss.backend.entity.ReviewReservation;
+
+import java.util.List;
+
 public interface ReviewReservationRepositoryCustom {
+    List<ReviewReservation> findByDiscussionId(Long discussionId);
 }

--- a/src/main/java/com/hidiscuss/backend/repository/ReviewReservationRepositoryImpl.java
+++ b/src/main/java/com/hidiscuss/backend/repository/ReviewReservationRepositoryImpl.java
@@ -1,13 +1,25 @@
 package com.hidiscuss.backend.repository;
 
+import com.hidiscuss.backend.entity.QReviewReservation;
+import com.hidiscuss.backend.entity.ReviewReservation;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
-public class ReviewReservationRepositoryImpl {
+public class ReviewReservationRepositoryImpl implements ReviewReservationRepositoryCustom {
     private final JPAQueryFactory queryFactory;
+    private final QReviewReservation qReviewReservation = QReviewReservation.reviewReservation;
 
     public ReviewReservationRepositoryImpl(JPAQueryFactory queryFactory) {
         this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public List<ReviewReservation> findByDiscussionId(Long discussionId) {
+        return queryFactory.selectFrom(qReviewReservation)
+                .where(qReviewReservation.discussion.id.eq(discussionId))
+                .fetch();
     }
 }

--- a/src/main/java/com/hidiscuss/backend/service/DiscussionService.java
+++ b/src/main/java/com/hidiscuss/backend/service/DiscussionService.java
@@ -50,4 +50,8 @@ public class DiscussionService {
         }
         return discussion;
     }
+
+    public Discussion findByIdOrNull(Long discussionId) {
+        return discussionRepository.findById(discussionId).orElse(null);
+    }
 }

--- a/src/main/java/com/hidiscuss/backend/service/EmailService.java
+++ b/src/main/java/com/hidiscuss/backend/service/EmailService.java
@@ -1,0 +1,38 @@
+package com.hidiscuss.backend.service;
+
+import com.hidiscuss.backend.controller.dto.SendEmailDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import javax.mail.internet.MimeMessage;
+import javax.transaction.Transactional;
+import javax.validation.Valid;
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class EmailService {
+
+    private final JavaMailSender javaMailSender;
+
+    public void send(@Valid SendEmailDto sendEmailDto) {
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+        MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, "UTF-8");
+        try {
+            sendEmailDto.applyHelper(mimeMessageHelper);
+        } catch (Exception e) {
+            log.error("send email error", e);
+            throw new RuntimeException(e); // TODO change to custom exception
+        }
+        javaMailSender.send(mimeMessage);
+    }
+
+    public void sendBatch(@Valid List<SendEmailDto> sendEmailDtos) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/service/ReviewReservationService.java
+++ b/src/main/java/com/hidiscuss/backend/service/ReviewReservationService.java
@@ -1,0 +1,74 @@
+package com.hidiscuss.backend.service;
+
+import com.hidiscuss.backend.entity.Discussion;
+import com.hidiscuss.backend.entity.LiveReviewAvailableTimes;
+import com.hidiscuss.backend.entity.ReviewReservation;
+import com.hidiscuss.backend.repository.ReviewReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ReviewReservationService {
+    public static int REVIEW_SESSION_DURATION_IN_HOURS = 1;
+
+    private final ReviewReservationRepository reviewReservationRepository;
+
+    public List<ReviewReservation> findByDiscussionId(Long discussionId) {
+        return reviewReservationRepository.findByDiscussionId(discussionId);
+    }
+
+
+    public ReviewReservation create(
+            LocalDateTime startTime,
+            Discussion discussion
+    ) {
+        Long discussionId = discussion.getId();
+        List<ReviewReservation> alreadyExistReviewReservation = this.findByDiscussionId(discussionId);
+        alreadyExistReviewReservation.forEach(reviewReservation -> {
+            if(isDuplicatedReviewReservation(startTime, reviewReservation)) {
+                throw new IllegalArgumentException("이미 예약된 시간입니다.");
+            }
+        });
+
+        LiveReviewAvailableTimes liveReviewAvailableTimes = discussion.getLiveReviewAvailableTimes();
+
+        boolean isAvailableInsert = liveReviewAvailableTimes.getTimes().stream().anyMatch(timeRange -> {
+          LocalDateTime start = timeRange.getStart();
+          LocalDateTime end = timeRange.getEnd();
+          return start.isBefore(startTime) && end.isAfter(startTime);
+        });
+
+        if(!isAvailableInsert) {
+            throw new IllegalArgumentException("예약 가능한 시간이 아닙니다.");
+        }
+
+        ReviewReservation reviewReservation = ReviewReservation.builder()
+                .reviewStartDateTime(startTime)
+                .discussion(discussion)
+                .reviewer(discussion.getUser()) // TODO IMPLEMENT : get Context User
+                .build();
+
+//        String revieweeEmail = discussion.getUser().getEmail();
+//        String reviewerEmail = reviewReservation.getReviewer().getEmail();
+
+        //emailService.send(revieweeEmail, "예약 알림", "예약이 완료되었습니다.");
+        //emailService.send(reviewerEmail, "예약 알림", "예약이 완료되었습니다.");
+
+        return reviewReservationRepository.save(reviewReservation);
+    }
+
+    private boolean isDuplicatedReviewReservation(LocalDateTime startTime, ReviewReservation reviewReservation) {
+        LocalDateTime comparerStartTime = reviewReservation.getReviewStartDateTime();
+        LocalDateTime comparerEndTime = comparerStartTime.plusHours(REVIEW_SESSION_DURATION_IN_HOURS);
+        boolean isEqual = comparerStartTime.isEqual(startTime);
+        boolean isBetween = comparerStartTime.isBefore(startTime) && comparerEndTime.isAfter(startTime);
+        boolean isStartBeforeHour = startTime.isAfter(comparerStartTime.minusHours(REVIEW_SESSION_DURATION_IN_HOURS)) && startTime.isBefore(comparerStartTime);
+        return isEqual || isBetween || isStartBeforeHour;
+    }
+}

--- a/src/main/java/com/hidiscuss/backend/utils/MailSenderProperties.java
+++ b/src/main/java/com/hidiscuss/backend/utils/MailSenderProperties.java
@@ -1,0 +1,23 @@
+package com.hidiscuss.backend.utils;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "spring.mail")
+public class MailSenderProperties {
+    private String host;
+    private int port;
+
+    private String username;
+    private String password;
+
+    // process nested properties..
+    private String propertiesMailSmtpAuth = "true";
+    private String propertiesMailSmtpStarttlsEnable = "true";
+}

--- a/src/main/resources/config/email/application.yml
+++ b/src/main/resources/config/email/application.yml
@@ -1,0 +1,12 @@
+spring:
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${EMAIL_USERNAME}
+    password: ${EMAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true

--- a/src/test/java/com/hidiscuss/backend/service/DiscussionServiceTest.java
+++ b/src/test/java/com/hidiscuss/backend/service/DiscussionServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -37,7 +38,7 @@ class DiscussionServiceTest {
 
     @BeforeEach
     void setUp() {
-        when(discussionRepository.save(Mockito.any(Discussion.class))).thenAnswer(i -> i.getArgument(0));
+        Mockito.lenient().when(discussionRepository.save(Mockito.any(Discussion.class))).thenAnswer(i -> i.getArgument(0));
     }
     @Test
     void serviceIsDefined() {
@@ -73,7 +74,7 @@ class DiscussionServiceTest {
     void createDiscussion_withLiveReview() {
         CreateDiscussionRequestDto dto = getCreateDiscussionRequestDto();
         dto.liveReviewRequired = true;
-        dto.liveReviewAvailableTimes = new LiveReviewAvailableTimes();
+        dto.liveReviewAvailableTimes = new LiveReviewAvailableTimes(List.of());
         User user = new User();
 
         Discussion discussion = discussionService.create(dto, user);
@@ -81,6 +82,15 @@ class DiscussionServiceTest {
         assertThat(discussion.getLiveReviewRequired()).isTrue();
         assertThat(discussion.getLiveReviewAvailableTimes()).isNotNull();
         assertThat(discussion).isNotNull();
+    }
+
+    @Test
+    void findById_Nullable() {
+        when(discussionRepository.findById(Mockito.anyLong())).thenReturn(Optional.empty());
+
+        Discussion discussion = discussionService.findByIdOrNull(1L);
+
+        assertThat(discussion).isNull();
     }
 
     private CreateDiscussionRequestDto getCreateDiscussionRequestDto() {

--- a/src/test/java/com/hidiscuss/backend/service/ReviewReservationServiceTest.java
+++ b/src/test/java/com/hidiscuss/backend/service/ReviewReservationServiceTest.java
@@ -1,0 +1,105 @@
+package com.hidiscuss.backend.service;
+
+import com.hidiscuss.backend.controller.dto.CreateReviewReservationRequestDto;
+import com.hidiscuss.backend.entity.Discussion;
+import com.hidiscuss.backend.entity.LiveReviewAvailableTimes;
+import com.hidiscuss.backend.entity.ReviewReservation;
+import com.hidiscuss.backend.repository.ReviewReservationRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ReviewReservationServiceTest {
+    @Mock
+    private ReviewReservationRepository reviewReservationRepository;
+    @InjectMocks
+    private ReviewReservationService reviewReservationService;
+
+    @Test
+    void serviceIsDefined() {
+        assertThat(reviewReservationService).isNotNull();
+    }
+
+    @Test
+    void findByDiscussionId() {
+        when(reviewReservationRepository.findByDiscussionId(1L)).thenReturn(List.of(ReviewReservation.builder().build()));
+
+        assertThat(reviewReservationService.findByDiscussionId(1L)).isNotEmpty();
+    }
+
+    @Test
+    void create_fail_when_invalid_discussionId() {
+
+    }
+
+    @Test
+    void create_fail_when_already_reserved() {
+        LocalDateTime givenTime = getBasisTime();
+        ReviewReservation givenReviewReservation = ReviewReservation.builder().reviewStartDateTime(givenTime).build();
+        Discussion discussion = getDiscussion(null);
+        LocalDateTime afterMinute = givenTime.plusMinutes(1);
+        LocalDateTime beforeMinute = givenTime.minusMinutes(1);
+
+        when(reviewReservationRepository.findByDiscussionId(discussion.getId())).thenReturn(List.of(givenReviewReservation));
+
+        assertThrows(IllegalArgumentException.class, () -> reviewReservationService.create(afterMinute, discussion));
+        assertThrows(IllegalArgumentException.class, () -> reviewReservationService.create(beforeMinute, discussion));
+    }
+
+    @Test
+    void create_fail_not_available_times() {
+        LocalDateTime givenTime = getBasisTime();
+
+        LiveReviewAvailableTimes.LiveReviewAvailableTime givenAvailableTime = new LiveReviewAvailableTimes.LiveReviewAvailableTime();
+        givenAvailableTime.setStart(givenTime.plusHours(1));
+        givenAvailableTime.setEnd(givenTime.plusHours(2));
+        LiveReviewAvailableTimes liveReviewAvailableTimes = new LiveReviewAvailableTimes(List.of(givenAvailableTime));
+        Discussion discussion = getDiscussion(liveReviewAvailableTimes);
+
+        when(reviewReservationRepository.findByDiscussionId(discussion.getId())).thenReturn(List.of());
+
+        assertThrows(IllegalArgumentException.class, () -> reviewReservationService.create(givenTime, discussion));
+    }
+
+    @Test
+    void create_success() {
+        LocalDateTime givenTime = getBasisTime();
+
+        LiveReviewAvailableTimes.LiveReviewAvailableTime givenAvailableTime = new LiveReviewAvailableTimes.LiveReviewAvailableTime();
+        givenAvailableTime.setStart(givenTime.minusHours(1));
+        givenAvailableTime.setEnd(givenTime.plusHours(1));
+        LiveReviewAvailableTimes liveReviewAvailableTimes = new LiveReviewAvailableTimes(List.of(givenAvailableTime));
+        Discussion discussion = getDiscussion(liveReviewAvailableTimes);
+
+
+        when(reviewReservationRepository.findByDiscussionId(discussion.getId())).thenReturn(List.of());
+
+        ReviewReservation createdReviewReservation = reviewReservationService.create(givenTime, discussion);
+
+        // check repository save method is called
+        verify(reviewReservationRepository, times(1)).save(Mockito.any(ReviewReservation.class));
+    }
+
+    private LocalDateTime getBasisTime() {
+        return LocalDateTime.of(2022, 3, 1, 12, 0);
+    }
+
+    private Discussion getDiscussion(LiveReviewAvailableTimes liveReviewAvailableTimes) {
+        return Discussion.builder()
+                .id(1L)
+                .liveReviewRequired(true)
+                .liveReviewAvailableTimes(liveReviewAvailableTimes)
+                .build();
+    }
+}


### PR DESCRIPTION
### 티켓
[CAPS-126](https://github.com/capstone-signal/backend-spring/pull/15)

### 추가사항
- 이메일 전송 관련 모듈 추가 `EmailService` `MailSenderConfig`
- 리뷰 예약 관련 서비스 로직 추가 
- `LiveReviewAvailableTimes` `equals` 와 `hashCode` 오버라이딩 => [Reference](https://docs.jboss.org/hibernate/stable/core.old/reference/en/html/persistent-classes-equalshashcode.html)
- 리뷰 예약 관련 쿼리 추가 => `querydsl` 이용
- 리뷰 예약 관련 테스트 로직 추가

### 변경사항
- `ReviewReservation` 네이밍 변경 => `reviewDate` -> `reviewStartDateTime`
- `LiveReviewAvailableTimes` 컨버터 => date string 파싱 오류로 인해 `ObjectMapper` 빈 주입으로 변경 
- **어플리케이션 실행 필요 환경변수 추가 `EMAIL_USERNAME` `EMAIL_PASSWORD`**

테스트 관련은 좀 더 수정해서 PR 한번더 올리겠습니다~

