### PR TITLE
Fix erd: 초기 설계에서 잘못 설계된 엔티티, 사용하지 않는 엔티티 수정

### DIFF
--- a/src/main/java/com/hidiscuss/backend/controller/dto/CreateDiscussionCodeRequestDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/CreateDiscussionCodeRequestDto.java
@@ -1,10 +1,9 @@
 package com.hidiscuss.backend.controller.dto;
 
-import com.hidiscuss.backend.entity.DiscussionCode;
-
 public class CreateDiscussionCodeRequestDto {
     public String filename;
     public String content;
+    public String language;
 
     public int getLength() {
         return content.length();

--- a/src/main/java/com/hidiscuss/backend/controller/dto/DiscussionCodeDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/DiscussionCodeDto.java
@@ -14,9 +14,10 @@ public class DiscussionCodeDto {
     public Long id;
     public String filename;
     public String content;
+    public String language;
 
     public static DiscussionCodeDto fromEntity(DiscussionCode entity) {
-        DiscussionCodeDto dto = new DiscussionCodeDto(entity.getId(), entity.getFilename(), entity.getContent());
+        DiscussionCodeDto dto = new DiscussionCodeDto(entity.getId(), entity.getFilename(), entity.getContent(), entity.getLanguage());
         return dto;
     }
 

--- a/src/main/java/com/hidiscuss/backend/entity/CommentReviewDiff.java
+++ b/src/main/java/com/hidiscuss/backend/entity/CommentReviewDiff.java
@@ -11,7 +11,7 @@ import javax.persistence.*;
 @Table(name = "CommentReviewDiff")
 public class CommentReviewDiff extends ReviewDiff {
 
-    @Column(name = "code_locate", nullable = false)
+    @Column(columnDefinition = "json", name = "code_locate", nullable = false)
     private String codeLocate;
 
     @Column(name = "comment", nullable = false)

--- a/src/main/java/com/hidiscuss/backend/entity/DiscussionCode.java
+++ b/src/main/java/com/hidiscuss/backend/entity/DiscussionCode.java
@@ -42,8 +42,11 @@ public class DiscussionCode extends BaseEntity {
     @Column(columnDefinition = "MEDIUMTEXT", name = "content", nullable = false)
     private String content;
 
+    @Column(name = "language", nullable = false)
+    private String language;
+
     @Builder
-    public DiscussionCode(Long id, Discussion discussion, String sha, String filename, Status status, Long additions, Long deletions, Long changes, String content) {
+    public DiscussionCode(Long id, Discussion discussion, String sha, String filename, Status status, Long additions, Long deletions, Long changes, String content, String language) {
         this.id = id;
         this.discussion = discussion;
         this.sha = sha;
@@ -53,5 +56,6 @@ public class DiscussionCode extends BaseEntity {
         this.deletions = deletions;
         this.changes = changes;
         this.content = content;
+        this.language = language;
     }
 }

--- a/src/main/java/com/hidiscuss/backend/entity/DiscussionCode.java
+++ b/src/main/java/com/hidiscuss/backend/entity/DiscussionCode.java
@@ -20,24 +20,8 @@ public class DiscussionCode extends BaseEntity {
     @JoinColumn(name = "discussion_id", nullable = false)
     private Discussion discussion;
 
-    @Column(name = "sha", nullable = false)
-    private String sha;
-
     @Column(name = "filename", nullable = false)
     private String filename;
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
-    private Status status;
-
-    @Column(name = "additions", nullable = false)
-    private Long additions;
-
-    @Column(name = "deletions", nullable = false)
-    private Long deletions;
-
-    @Column(name = "changes", nullable = false)
-    private Long changes;
 
     @Column(columnDefinition = "MEDIUMTEXT", name = "content", nullable = false)
     private String content;
@@ -46,15 +30,10 @@ public class DiscussionCode extends BaseEntity {
     private String language;
 
     @Builder
-    public DiscussionCode(Long id, Discussion discussion, String sha, String filename, Status status, Long additions, Long deletions, Long changes, String content, String language) {
+    public DiscussionCode(Long id, Discussion discussion, String filename, String content, String language) {
         this.id = id;
         this.discussion = discussion;
-        this.sha = sha;
         this.filename = filename;
-        this.status = status;
-        this.additions = additions;
-        this.deletions = deletions;
-        this.changes = changes;
         this.content = content;
         this.language = language;
     }

--- a/src/main/java/com/hidiscuss/backend/entity/ReviewDiff.java
+++ b/src/main/java/com/hidiscuss/backend/entity/ReviewDiff.java
@@ -25,7 +25,7 @@ public abstract class ReviewDiff extends BaseEntity {
     @JoinColumn(name = "discussion_code_id", nullable = false)
     private DiscussionCode discussionCode;
 
-    @Column(name = "code_after", nullable = false)
+    @Column(columnDefinition = "mediumtext", name = "code_after", nullable = false)
     private String codeAfter;
 
 }

--- a/src/main/java/com/hidiscuss/backend/service/DiscussionCodeService.java
+++ b/src/main/java/com/hidiscuss/backend/service/DiscussionCodeService.java
@@ -34,6 +34,7 @@ public class DiscussionCodeService {
                     .additions((long) d.getLength())
                     .deletions(0L)
                     .changes(0L)
+                    .language(d.language)
                     .build();
             codes.add(code);
         });

--- a/src/main/java/com/hidiscuss/backend/service/DiscussionCodeService.java
+++ b/src/main/java/com/hidiscuss/backend/service/DiscussionCodeService.java
@@ -29,11 +29,6 @@ public class DiscussionCodeService {
                     .discussion(discussion)
                     .filename(d.filename)
                     .content(d.content)
-                    .sha("DIRECT")
-                    .status(Status.ADDED)
-                    .additions((long) d.getLength())
-                    .deletions(0L)
-                    .changes(0L)
                     .language(d.language)
                     .build();
             codes.add(code);
@@ -51,22 +46,12 @@ public class DiscussionCodeService {
             if (f instanceof GHPullRequestFileDetail) {
                 GHPullRequestFileDetail file = (GHPullRequestFileDetail) f;
                 builder.filename(file.getFilename())
-                        .content(file.getPatch())
-                        .sha(file.getSha())
-                        .status(Status.convertFromGithubStatus(file.getStatus()))
-                        .additions((long) file.getAdditions())
-                        .deletions((long) file.getDeletions())
-                        .changes((long) file.getChanges());
+                        .content(file.getPatch());
 
             } else if (f instanceof GHCommit.File) {
                 GHCommit.File file = (GHCommit.File) f;
                 builder.filename(file.getFileName())
-                        .content(file.getPatch())
-                        .sha(file.getSha())
-                        .status(Status.convertFromGithubStatus(file.getStatus()))
-                        .additions((long) file.getLinesAdded())
-                        .deletions((long) file.getLinesDeleted())
-                        .changes((long) file.getLinesChanged());
+                        .content(file.getPatch());
             } else {
                 throw new IllegalArgumentException("Unknown file type");
             }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -16,9 +16,10 @@ INSERT INTO `hidiscuss`.`review` (`id`, `created_at`, `last_modified_at`, `accep
 
 -- commentReviewDiff(id 7400, 7401) 생성
 INSERT INTO `hidiscuss`.`comment_review_diff` (`id`, `created_at`, `last_modified_at`, `code_after`, `code_locate`, `comment`, `discussion_code_id`, `review_id`) VALUES
-    (7400, NOW(), NOW(), 'string', 'string', 'string', 7200, 7300);
+    (7400, NOW(), NOW(), 'ss', '{}', 'd', 7200, 7300);
 INSERT INTO `hidiscuss`.`comment_review_diff` (`id`, `created_at`, `last_modified_at`, `code_after`, `code_locate`, `comment`, `discussion_code_id`, `review_id`) VALUES
-    (7401, NOW(), NOW(), 'string', 'string', 'string', 7200, 7300);
+    (7401, NOW(), NOW(), 'ss', '{}', 'd', 7200, 7300);
+
 
 -- liveReviewDiff(id 7500) 생성
 INSERT INTO `hidiscuss`.`live_review_diff` (`id`, `created_at`, `last_modified_at`, `code_after`, `discussion_code_id`, `review_id`) VALUES

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -6,8 +6,10 @@ INSERT INTO `discussion` (`id`, `created_at`, `last_modified_at`, `live_review_a
     (7100, NOW(), NOW(), '{\"times\": [{\"end\": \"2022-04-28T15:00:21.386Z\", \"start\": \"2022-04-27T11:02:21.386Z\"}]}', 1, 0, '0', 'NOT_REVIEWED', 'title', 7000);
 
 -- discussionCode(id 7200, 7201) 생성
-INSERT INTO `hidiscuss`.`discussion_code` (`id`, `created_at`, `last_modified_at`, `additions`, `changes`, `content`, `deletions`, `filename`, `sha`, `status`, `discussion_id`, `language`) VALUES (7200, NOW(), NOW(), 1, 1, '1', 1, '1', '1', 'ADDED', 7100, 'jave');
-INSERT INTO `hidiscuss`.`discussion_code` (`id`, `created_at`, `last_modified_at`, `additions`, `changes`, `content`, `deletions`, `filename`, `sha`, `status`, `discussion_id`, `language`) VALUES (7201, NOW(), NOW(), 1, 1, '1', 1, '1', '1', 'ADDED', 7100, 'typescript');
+INSERT INTO `discussion_code` (`id`, `created_at`, `last_modified_at`, `content`, `filename`, `language`, `discussion_id`) VALUES
+    (7200, NOW(), NOW(), 'content', 'filename', 'language', 7100);
+INSERT INTO `discussion_code` (`id`, `created_at`, `last_modified_at`, `content`, `filename`, `language`, `discussion_id`) VALUES
+    (7201, NOW(), NOW(), 'content', 'filename', 'language', 7100);
 
 -- review(id 7300) 생성
 INSERT INTO `hidiscuss`.`review` (`id`, `created_at`, `last_modified_at`, `accepted`, `review_type`, `discussion_id`, `reviewer_id`) VALUES(7300, NOW(), NOW(), 0, 'COMMENT', 7100, 7000);

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -6,8 +6,8 @@ INSERT INTO `discussion` (`id`, `created_at`, `last_modified_at`, `live_review_a
     (7100, NOW(), NOW(), '{\"times\": [{\"end\": \"2022-04-28T15:00:21.386Z\", \"start\": \"2022-04-27T11:02:21.386Z\"}]}', 1, 0, '0', 'NOT_REVIEWED', 'title', 7000);
 
 -- discussionCode(id 7200, 7201) 생성
-INSERT INTO `hidiscuss`.`discussion_code` (`id`, `created_at`, `last_modified_at`, `additions`, `changes`, `content`, `deletions`, `filename`, `sha`, `status`, `discussion_id`) VALUES (7200, NOW(), NOW(), 1, 1, '1', 1, '1', '1', 'ADDED', 7100);
-INSERT INTO `hidiscuss`.`discussion_code` (`id`, `created_at`, `last_modified_at`, `additions`, `changes`, `content`, `deletions`, `filename`, `sha`, `status`, `discussion_id`) VALUES (7201, NOW(), NOW(), 1, 1, '1', 1, '1', '1', 'ADDED', 7100);
+INSERT INTO `hidiscuss`.`discussion_code` (`id`, `created_at`, `last_modified_at`, `additions`, `changes`, `content`, `deletions`, `filename`, `sha`, `status`, `discussion_id`, `language`) VALUES (7200, NOW(), NOW(), 1, 1, '1', 1, '1', '1', 'ADDED', 7100, 'jave');
+INSERT INTO `hidiscuss`.`discussion_code` (`id`, `created_at`, `last_modified_at`, `additions`, `changes`, `content`, `deletions`, `filename`, `sha`, `status`, `discussion_id`, `language`) VALUES (7201, NOW(), NOW(), 1, 1, '1', 1, '1', '1', 'ADDED', 7100, 'typescript');
 
 -- review(id 7300) 생성
 INSERT INTO `hidiscuss`.`review` (`id`, `created_at`, `last_modified_at`, `accepted`, `review_type`, `discussion_id`, `reviewer_id`) VALUES(7300, NOW(), NOW(), 0, 'COMMENT', 7100, 7000);

--- a/src/test/java/com/hidiscuss/backend/service/DiscussionCodeServiceTest.java
+++ b/src/test/java/com/hidiscuss/backend/service/DiscussionCodeServiceTest.java
@@ -65,7 +65,6 @@ public class DiscussionCodeServiceTest {
         List<GHCommit.File> files = new ArrayList<>();
         GHCommit.File file = Mockito.mock(GHCommit.File.class);
         when(file.getPatch()).thenReturn(null);
-        when(file.getStatus()).thenReturn("added");
         files.add(file);
 
         Exception ex = assertThrows(EmptyDiscussionCodeException.class, () -> discussionCodeService.createFromFiles(discussion, files));
@@ -79,7 +78,6 @@ public class DiscussionCodeServiceTest {
         GHCommit.File file = Mockito.mock(GHCommit.File.class);
         when(file.getFileName()).thenReturn("test.java");
         when(file.getPatch()).thenReturn("test");
-        when(file.getStatus()).thenReturn("added");
         files.add(file);
 
         List<DiscussionCode> discussionCodes = discussionCodeService.createFromFiles(discussion, files);

--- a/src/test/java/com/hidiscuss/backend/service/DiscussionCodeServiceTest.java
+++ b/src/test/java/com/hidiscuss/backend/service/DiscussionCodeServiceTest.java
@@ -102,6 +102,7 @@ public class DiscussionCodeServiceTest {
         CreateDiscussionCodeRequestDto createDiscussionCodeRequestDto = new CreateDiscussionCodeRequestDto();
         createDiscussionCodeRequestDto.filename = "filename";
         createDiscussionCodeRequestDto.content = "code";
+        createDiscussionCodeRequestDto.language = "language";
         return createDiscussionCodeRequestDto;
     }
 }

--- a/src/test/java/com/hidiscuss/backend/service/DiscussionServiceTest.java
+++ b/src/test/java/com/hidiscuss/backend/service/DiscussionServiceTest.java
@@ -136,6 +136,7 @@ class DiscussionServiceTest {
         CreateDiscussionCodeRequestDto dto = new CreateDiscussionCodeRequestDto();
         dto.content = "content";
         dto.filename = "filename";
+        dto.language = "language";
         return dto;
     }
 }

--- a/src/test/java/com/hidiscuss/backend/service/ReviewServiceTest.java
+++ b/src/test/java/com/hidiscuss/backend/service/ReviewServiceTest.java
@@ -126,7 +126,7 @@ public class ReviewServiceTest {
     }
 
     private CreateCommentReviewDiffDto getCommentReviewDiffDto(Long id) {
-        DiscussionCodeDto dto = new DiscussionCodeDto(id, "filename", "content");
+        DiscussionCodeDto dto = new DiscussionCodeDto(id, "filename", "content", "language");
         return new CreateCommentReviewDiffDto(dto, "codeAfter", "codeLocate", "comment");
     }
 }


### PR DESCRIPTION
## 티켓
없음!

## 작업 내용
- [x] `DiscussionCode` 테이블에서 `sha`, `status`, `addition`, `deletion`,`change` 컬럼 삭제
- [x] `DiscussionCode` 테이블에 `language` 컬럼 추가
  - 영향범위: `CreateDiscussionCodeRequestDto`, `DiscussionCodeDto`, `DiscussionCodeService`, `DiscussionCodeServiceTest`, `DiscussionServiceTest`, `data.sql`
  - 테스트 방법: 테스트 코드 돌리기, API 호출해 결과 확인(Discussion 생성 API, Discussion 상세 조회 API)
- [x] CommentReviewDiff 에서 code_locate 선언 JSON 타입으로 변경
- [x] LiveReviewDif에서 code_after 선언 MEDIUMTEXT 로 변경

## 전달사항
회의때 conflict 해결하면서 함께 merge해보면 좋을 것 같습니다..ㅎㅎ