### PR TITLE
Fix/fetchjoin: 쿼리가 두 번 나가는 문제 수정

### DIFF
--- a/src/main/java/com/hidiscuss/backend/repository/DiscussionCodeRepositoryCustom.java
+++ b/src/main/java/com/hidiscuss/backend/repository/DiscussionCodeRepositoryCustom.java
@@ -5,5 +5,6 @@ import com.hidiscuss.backend.entity.DiscussionCode;
 import java.util.List;
 
 public interface DiscussionCodeRepositoryCustom {
-    List<DiscussionCode> findByIdListFetch(List<Long> list);
+    List<DiscussionCode> findByIdList(List<Long> list);
 }
+

--- a/src/main/java/com/hidiscuss/backend/repository/DiscussionCodeRepositoryImpl.java
+++ b/src/main/java/com/hidiscuss/backend/repository/DiscussionCodeRepositoryImpl.java
@@ -17,7 +17,7 @@ public class DiscussionCodeRepositoryImpl implements DiscussionCodeRepositoryCus
     }
 
     @Override
-    public List<DiscussionCode> findByIdListFetch(List<Long> list) {
+    public List<DiscussionCode> findByIdList(List<Long> list) {
         return queryFactory.selectFrom(qDiscussionCode)
                 .where(qDiscussionCode.id.in(list))
                 .fetch();

--- a/src/main/java/com/hidiscuss/backend/repository/DiscussionRepositoryImpl.java
+++ b/src/main/java/com/hidiscuss/backend/repository/DiscussionRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.hidiscuss.backend.repository;
 
 import com.hidiscuss.backend.entity.Discussion;
 import com.hidiscuss.backend.entity.QDiscussion;
+import com.hidiscuss.backend.entity.QUser;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.stereotype.Repository;
 
@@ -12,6 +13,7 @@ import java.util.Optional;
 public class DiscussionRepositoryImpl implements DiscussionRepositoryCustom{
     private final JPAQueryFactory queryFactory;
     private final QDiscussion qDiscussion = QDiscussion.discussion;
+    private final QUser qUser = QUser.user;
 
     public DiscussionRepositoryImpl(JPAQueryFactory queryFactory) {
         this.queryFactory = queryFactory;
@@ -20,6 +22,7 @@ public class DiscussionRepositoryImpl implements DiscussionRepositoryCustom{
     @Override
     public Discussion findByIdFetchOrNull(Long id) {
         return queryFactory.selectFrom(qDiscussion)
+                .join(qDiscussion.user, qUser).fetchJoin()
                 .where(qDiscussion.id.eq(id))
                 .fetchOne();
     }

--- a/src/main/java/com/hidiscuss/backend/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/hidiscuss/backend/repository/ReviewRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.hidiscuss.backend.repository;
 
+import com.hidiscuss.backend.entity.QDiscussion;
 import com.hidiscuss.backend.entity.QReview;
 import com.hidiscuss.backend.entity.Review;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -14,6 +15,7 @@ import java.util.List;
 public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
     private final JPAQueryFactory queryFactory;
     private final QReview qReview = QReview.review;
+//    private final QDiscussion qDiscussion = QDiscussion.discussion;
 
     public ReviewRepositoryImpl(JPAQueryFactory queryFactory) {
         this.queryFactory = queryFactory;
@@ -22,6 +24,8 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
     @Override
     public Review findByIdFetchOrNull(Long id) {
         return queryFactory.selectFrom(qReview)
+                .join(qReview.discussion).fetchJoin()
+                .join(qReview.reviewer).fetchJoin()
                 .where(qReview.id.eq(id))
                 .fetchOne();
     }

--- a/src/main/java/com/hidiscuss/backend/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/hidiscuss/backend/repository/ReviewRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.hidiscuss.backend.repository;
 
 import com.hidiscuss.backend.entity.QDiscussion;
+import com.hidiscuss.backend.entity.QDiscussionCode;
 import com.hidiscuss.backend.entity.QReview;
 import com.hidiscuss.backend.entity.Review;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -15,7 +16,7 @@ import java.util.List;
 public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
     private final JPAQueryFactory queryFactory;
     private final QReview qReview = QReview.review;
-//    private final QDiscussion qDiscussion = QDiscussion.discussion;
+//    private final QDiscussionCode qDiscussionCode = QDiscussionCode.discussionCode;
 
     public ReviewRepositoryImpl(JPAQueryFactory queryFactory) {
         this.queryFactory = queryFactory;
@@ -34,6 +35,11 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
     public Page<Review> findAllByDiscussionIdFetch(Long discussionId, PageRequest pageRequest) {
         List<Review> result = queryFactory.selectFrom(qReview)
                 .where(qReview.discussion.id.eq(discussionId))
+                .join(qReview.reviewer).fetchJoin()
+//                .join(qReview.commentDiffList).fetchJoin()
+//                .join(qReview.liveDiffList).fetchJoin()
+                .join(qReview.discussion).fetchJoin()
+//                .join(qDiscussionCode).fetchJoin()
                 .offset(pageRequest.getOffset())
                 .limit(pageRequest.getPageSize())
                 .fetch();

--- a/src/main/java/com/hidiscuss/backend/service/CommentReviewDiffService.java
+++ b/src/main/java/com/hidiscuss/backend/service/CommentReviewDiffService.java
@@ -25,7 +25,7 @@ public class CommentReviewDiffService {
 
         for (int i = 0; i < list.size(); i++)
             idList.add(list.get(i).getDiscussionCode().getId());
-        List<DiscussionCode> codeList = discussionCodeRepository.findByIdListFetch(idList);
+        List<DiscussionCode> codeList = discussionCodeRepository.findByIdList(idList);
 
         if (codeList.size() != 0) {
             for (int i = 0; i < list.size(); i++) {


### PR DESCRIPTION
## 티켓
없음!

## 작업 내용
- [x] `DiscussionRepositoryImpl`의 `findByIdFetchOrNull` fetchJoin하도록 수정
- [x] `DiscussionCodeRepositoryImpl`의 `findByIdFetchList` -> `findByIdList`로 네이밍 변경(fetchjoin이 필요없는 메서드로 판단)
- [x] `ReviewRepositoryImpl`의 `findByIdFetchOrNull`, `findAllByDiscussionIdFetch`를 fetchJoin하도록 일부 수정

## 질문
- `ReviewRepositoryImpl`의 `findAllByDiscussionIdFetch`를 호출했을 때 여전히 필요한 모든 엔티티를 한번에 가져오지 못하는데 개선 방안을 잘 모르겠습니다... commentReviewDiff와 LiveReviewDiff를 함께 join시키면서 가져오려면 쿼리를 어떻게 작성해야 할까요..?
