### PR TITLE
Fix/discussionDetail: 상세 페이지 조회 시 스레드 가져오도록 변경

### DIFF
--- a/src/main/java/com/hidiscuss/backend/controller/dto/ReviewDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/ReviewDto.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 public class ReviewDto extends BaseResponseDto {
@@ -15,6 +16,7 @@ public class ReviewDto extends BaseResponseDto {
     private UserResponseDto reviewer;
     private List<CommentReviewDiffResponseDto> commentDiffList = new ArrayList<>();
     private List<LiveReviewDiffResponseDto> liveDiffList = new ArrayList<>();
+    private List<ThreadResponseDto> threadList = new ArrayList<>();
     private Boolean accepted;
     private ReviewType reviewType;
 
@@ -34,6 +36,7 @@ public class ReviewDto extends BaseResponseDto {
             for (LiveReviewDiff item : entityList)
                 dto.liveDiffList.add(LiveReviewDiffResponseDto.fromEntity(item));
         }
+        dto.threadList = review.getThreadList().stream().map(i -> ThreadResponseDto.fromEntity(i)).collect(Collectors.toList());
         return dto;
     }
 }

--- a/src/main/java/com/hidiscuss/backend/controller/dto/ThreadResponseDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/ThreadResponseDto.java
@@ -9,8 +9,6 @@ public class ThreadResponseDto extends BaseResponseDto {
 
     private UserResponseDto user;
 
-    private CommentReviewResponseDto review;
-
     private String content;
 
     public static ThreadResponseDto fromEntity(ReviewThread entity) {
@@ -18,7 +16,6 @@ public class ThreadResponseDto extends BaseResponseDto {
         dto.setBaseResponse(entity);
         dto.id = entity.getId();
         dto.user = UserResponseDto.fromEntity(entity.getUser());
-        dto.review = CommentReviewResponseDto.fromEntity(entity.getReview());
         dto.content = entity.getContent();
         return dto;
     }

--- a/src/main/java/com/hidiscuss/backend/entity/Review.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Review.java
@@ -36,6 +36,9 @@ public class Review extends BaseEntity {
     @OneToMany(mappedBy = "review")
     private List<LiveReviewDiff> liveDiffList = new ArrayList<>();
 
+    @OneToMany(mappedBy = "review")
+    private List<ReviewThread> threadList = new ArrayList<>();
+
     @Column(columnDefinition ="boolean default false", name = "accepted", nullable = false)
     private Boolean accepted;
 
@@ -44,12 +47,13 @@ public class Review extends BaseEntity {
     private ReviewType reviewType;
 
     @Builder
-    public Review(Long id, User reviewer, Discussion discussion, List<CommentReviewDiff> commentDiffList, List<LiveReviewDiff> liveDiffList, Boolean accepted, ReviewType reviewType) {
+    public Review(Long id, User reviewer, Discussion discussion, List<CommentReviewDiff> commentDiffList, List<LiveReviewDiff> liveDiffList, List<ReviewThread> threadList, Boolean accepted, ReviewType reviewType) {
         this.id = id;
         this.reviewer = reviewer;
         this.discussion = discussion;
         this.commentDiffList = commentDiffList;
         this.liveDiffList = liveDiffList;
+        this.threadList = threadList;
         this.accepted = accepted;
         this.reviewType = reviewType;
     }
@@ -62,6 +66,7 @@ public class Review extends BaseEntity {
                 ", discussion=" + discussion +
                 ", commentDiffList=" + commentDiffList +
                 ", liveDiffList=" + liveDiffList +
+                ", threadList=" + threadList +
                 ", accepted=" + accepted +
                 ", reviewType=" + reviewType +
                 '}';


### PR DESCRIPTION
## 티켓
없음!

## 작업 내용
- [x] `getReviews`로 리뷰 리스트 호출 시 Page<Review> 에 포함된 스레드 리스트도 함께 가져오도록 변경
- [x] `saveThread`로 스레드 저장할 때 responseDto에 포함되었던 review 엔티티 삭제

## 전달사항
- 다른 브랜치들 머지한 후 스레드도 fetchJoin 사용할 수 있도록 변경할 필요가 있습니다.
- 스레드 저장 시 responseDto에 포함되었던 review 엔티티를 삭제하면 혹시 프론트 코드에 영향이 있을까요?
