### PR TITLE
Fix/GitHub API : 엑세스 토큰을 통해 API 접근하게 수정

### DIFF
--- a/src/main/java/com/hidiscuss/backend/Oauth/JwtAuthFilter.java
+++ b/src/main/java/com/hidiscuss/backend/Oauth/JwtAuthFilter.java
@@ -1,11 +1,13 @@
 package com.hidiscuss.backend.Oauth;
 
+import com.hidiscuss.backend.config.SecurityConfig;
 import com.hidiscuss.backend.entity.Token;
 import com.hidiscuss.backend.service.TokenService;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.GenericFilterBean;
@@ -30,8 +32,7 @@ public class JwtAuthFilter extends GenericFilterBean {
         HttpServletResponse res = (HttpServletResponse) response;
         HttpServletRequest req = (HttpServletRequest) request;
 
-        final List AUTHORITIES = new ArrayList();
-        AUTHORITIES.add(new SimpleGrantedAuthority("ROLE_USER"));
+        final List<GrantedAuthority> AUTHORITIES = List.of(new SimpleGrantedAuthority(SecurityConfig.DEFAULT_ROLE));
 
         String token = null;
         String refreshToken = null;
@@ -46,9 +47,10 @@ public class JwtAuthFilter extends GenericFilterBean {
             }
         }
         if (token != null && tokenService.verifyToken(token)) {
+            Claims claims = tokenService.parseJwtToken(token);
             String name = tokenService.getUid(token);
 
-            Authentication auth = new UsernamePasswordAuthenticationToken(name,"", AUTHORITIES);
+            Authentication auth = new UsernamePasswordAuthenticationToken(name, claims.get("gitAccessToken"), AUTHORITIES);
             SecurityContextHolder.getContext().setAuthentication(auth);
         }else if (refreshToken != null && tokenService.verifyToken(refreshToken)) {
             Claims claims = tokenService.parseJwtToken(refreshToken);

--- a/src/main/java/com/hidiscuss/backend/config/SecurityConfig.java
+++ b/src/main/java/com/hidiscuss/backend/config/SecurityConfig.java
@@ -24,6 +24,7 @@ import java.util.List;
 @Configuration
 @EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true, jsr250Enabled = true)
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
+    public static final String DEFAULT_ROLE = "ROLE_USER";
     private final CustomOAuth2UserService oAuth2UserService;
     private final OAuth2SuccessHandler successHandler;
     private final TokenService tokenService;

--- a/src/main/java/com/hidiscuss/backend/config/WebMvcConfig.java
+++ b/src/main/java/com/hidiscuss/backend/config/WebMvcConfig.java
@@ -16,8 +16,8 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("*")
-                .allowedOrigins("http://localhost:3000","https://github.com")
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("*").allowCredentials(true);
     }

--- a/src/main/java/com/hidiscuss/backend/config/WebMvcConfig.java
+++ b/src/main/java/com/hidiscuss/backend/config/WebMvcConfig.java
@@ -1,17 +1,16 @@
 package com.hidiscuss.backend.config;
 
-import com.hidiscuss.backend.config.interceptor.GithubInterceptor;
+import com.hidiscuss.backend.config.interceptor.GitHubClearInterceptor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
 @Configuration
 public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(new GithubInterceptor()).order(1); // TODO : order 수정 => after authentication
+        registry.addInterceptor(new GitHubClearInterceptor()).order(Integer.MIN_VALUE);
     }
 
     @Override

--- a/src/main/java/com/hidiscuss/backend/config/interceptor/GitHubClearInterceptor.java
+++ b/src/main/java/com/hidiscuss/backend/config/interceptor/GitHubClearInterceptor.java
@@ -19,15 +19,6 @@ public class GithubInterceptor implements HandlerInterceptor {
             HttpServletResponse response,
             Object handler
     ) throws Exception {
-        GitHub github = GitHub.connectAnonymously();
-        //Github github = new GitHubBuilder().withOAuthToken("request...").build();
-        // TODO : github instance based on access token
-
-        GHRateLimit rateLimit = github.getRateLimit();
-        if(rateLimit.getRemaining() < 1) {
-            throw new RuntimeException("Github API rate limit exceeded"); // TODO : custom exception
-        }
-        GithubContext.setInstance(github);
         return true;
     }
 

--- a/src/main/java/com/hidiscuss/backend/config/interceptor/GitHubClearInterceptor.java
+++ b/src/main/java/com/hidiscuss/backend/config/interceptor/GitHubClearInterceptor.java
@@ -11,7 +11,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 @Component
-public class GithubInterceptor implements HandlerInterceptor {
+public class GitHubClearInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(

--- a/src/main/java/com/hidiscuss/backend/controller/GithubController.java
+++ b/src/main/java/com/hidiscuss/backend/controller/GithubController.java
@@ -1,12 +1,13 @@
 package com.hidiscuss.backend.controller;
 
+import com.hidiscuss.backend.config.SecurityConfig;
 import com.hidiscuss.backend.controller.dto.GHCommitResponseDto;
 import com.hidiscuss.backend.controller.dto.GHPullRequestResponseDto;
 import com.hidiscuss.backend.controller.dto.GHRepositoryResponseDto;
 import com.hidiscuss.backend.service.GithubService;
-import com.hidiscuss.backend.utils.GithubContext;
 import lombok.AllArgsConstructor;
 import org.kohsuke.github.*;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Collection;
@@ -14,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@Secured(SecurityConfig.DEFAULT_ROLE)
 @RestController
 @RequestMapping("/github")
 @AllArgsConstructor

--- a/src/main/java/com/hidiscuss/backend/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/hidiscuss/backend/controller/GlobalExceptionHandler.java
@@ -11,6 +11,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.nio.file.AccessDeniedException;
+
 @RestControllerAdvice
 public class GlobalExceptionHandler {
     private final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
@@ -41,6 +43,12 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public String handleException(GithubException e) {
         logger.error(e.getMessage());
+        return e.getMessage();
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public String handleException(AccessDeniedException e) {
         return e.getMessage();
     }
 

--- a/src/main/java/com/hidiscuss/backend/service/GithubService.java
+++ b/src/main/java/com/hidiscuss/backend/service/GithubService.java
@@ -18,8 +18,9 @@ public class GithubService {
 
     public Collection<GHRepository> getRepositories() {
         try {
-            return getGitHub().getUser("capstone-signal").getRepositories().values(); // TODO : get user from session
+            return getGitHub().getMyself().getRepositories().values(); // TODO : get user from session
         } catch (IOException e) {
+            e.printStackTrace();
             throw new GithubException("Failed to get repositories", e);
         }
     }

--- a/src/main/java/com/hidiscuss/backend/utils/GithubContext.java
+++ b/src/main/java/com/hidiscuss/backend/utils/GithubContext.java
@@ -2,19 +2,33 @@ package com.hidiscuss.backend.utils;
 
 
 import org.kohsuke.github.GitHub;
+import org.kohsuke.github.GitHubBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 public class GithubContext {
     private static final ThreadLocal<GitHub> context = new ThreadLocal<>();
 
     public static GitHub getInstance() {
-        return context.get();
+        if (context.get() == null) {
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            if (authentication == null) {
+                throw new IllegalStateException("No authentication found in SecurityContextHolder");
+            }
+            String githubToken = authentication.getCredentials().toString();
+            try {
+                GitHub github = new GitHubBuilder().withOAuthToken(githubToken).build();
+                context.set(github);
+                return github;
+            } catch (Exception e) {
+                throw new IllegalStateException("Failed to create GitHub instance", e);
+            }
+        } else {
+            return context.get();
+        }
     }
 
     public static void clear() {
         context.remove();
-    }
-
-    public static void setInstance(GitHub gitHub) {
-        context.set(gitHub);
     }
 }


### PR DESCRIPTION
## 티켓

[CAPS-?](link)

## 작업 내용
- [x]  `GithubController` 인증된 유저만 접근 가능하게 수정
- [x] 2 `GitHub` 객체 인증 관련 => `GithubInterceptor`에서 `GithubContext`로 변경 : 모든 요청에 `Github` 객체 필요 없음
- [x] 기타) CORS 수정, access denied 예외 `GlobalExceptionHandler`에서 받게 수정
