### PR TITLE
Fix/DiscussionCode-language: pr, commit에서 discussionCode 불러올 때 language 누락

### DIFF
--- a/src/main/java/com/hidiscuss/backend/service/DiscussionCodeService.java
+++ b/src/main/java/com/hidiscuss/backend/service/DiscussionCodeService.java
@@ -3,18 +3,19 @@ package com.hidiscuss.backend.service;
 import com.hidiscuss.backend.controller.dto.CreateDiscussionCodeRequestDto;
 import com.hidiscuss.backend.entity.Discussion;
 import com.hidiscuss.backend.entity.DiscussionCode;
-import com.hidiscuss.backend.entity.Status;
 import com.hidiscuss.backend.exception.EmptyDiscussionCodeException;
 import com.hidiscuss.backend.repository.DiscussionCodeRepository;
 import lombok.AllArgsConstructor;
 import org.kohsuke.github.GHCommit;
-import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHPullRequestFileDetail;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+
+import static java.util.Map.entry;
 
 @Service
 @AllArgsConstructor
@@ -46,12 +47,14 @@ public class DiscussionCodeService {
             if (f instanceof GHPullRequestFileDetail) {
                 GHPullRequestFileDetail file = (GHPullRequestFileDetail) f;
                 builder.filename(file.getFilename())
-                        .content(file.getPatch());
+                        .content(file.getPatch())
+                        .language(getLanguageFromName(file.getFilename()));
 
             } else if (f instanceof GHCommit.File) {
                 GHCommit.File file = (GHCommit.File) f;
                 builder.filename(file.getFileName())
-                        .content(file.getPatch());
+                        .content(file.getPatch())
+                        .language(getLanguageFromName(file.getFileName()));
             } else {
                 throw new IllegalArgumentException("Unknown file type");
             }
@@ -64,6 +67,31 @@ public class DiscussionCodeService {
             throw new EmptyDiscussionCodeException("No codes found");
         }
         return discussionCodeRepository.saveAll(codes);
+    }
+
+    private String getLanguageFromName(String filename) {
+        Map<String, String> extLangMap = Map.ofEntries(
+                entry("js", "JavaScript"),
+                entry("ts", "TypeScript"),
+                entry("java", "Java"),
+                entry("py", "Python"),
+                entry("c", "C"),
+                entry("cs", "C#"),
+                entry("cpp", "C++"),
+                entry("html", "HTML"),
+                entry("xml", "XML"),
+                entry("php", "PHP"),
+                entry("json", "JSON"),
+                entry("md", "Markdown"),
+                entry("ps1", "Powershell"),
+                entry("rb", "Ruby"),
+                entry("css", "CSS"),
+                entry("scss", "SCSS"),
+                entry("sass", "SASS"),
+                entry("r", "R")
+        );
+        String language = extLangMap.get(filename.substring(filename.lastIndexOf(".") + 1));
+        return (language == null) ? "etc" : language;
     }
 
     public List<DiscussionCode> getDiscussionCode(Discussion discussion) {


### PR DESCRIPTION
## 티켓
없음!

## 작업 내용
discussion을 pr, commit으로부터 생성할 때 `DiscussionCode.language` 필드 채웠습니다.
`GHPullRequestFileDetail`랑 `GHCommit.File`에 language 속성이 없어서 파일 확장자로 찾도록 `getLanguageFromName` 메서드 작성했습니다!

## 논의사항
[이 파일](https://gist.github.com/ppisarczyk/43962d06686722d26d176fad46879d41)을 보고 언어와 대표적인 확장자를 매칭했는데, 한 언어가 여러 확장자를 가질 수 있는 경우에는 어떻게 처리하는게 좋을까요?