### PR TITLE
Fix/0522 api update: 수정 요청 사항 반영

### DIFF
--- a/src/main/java/com/hidiscuss/backend/controller/DiscussionController.java
+++ b/src/main/java/com/hidiscuss/backend/controller/DiscussionController.java
@@ -112,7 +112,7 @@ public class DiscussionController {
         return discussionService.delete(discussion, user);
     }
 
-    @PutMapping("/{discussionId}")
+    @PutMapping("/{discussionId}/complete")
     @Secured(SecurityConfig.DEFAULT_ROLE)
     @ApiOperation(value = "Discussion 완료")
     @ApiResponses({

--- a/src/main/java/com/hidiscuss/backend/controller/ReviewController.java
+++ b/src/main/java/com/hidiscuss/backend/controller/ReviewController.java
@@ -75,11 +75,11 @@ public class ReviewController {
             @ApiResponse(code = 400, message = "잘못된 요청"),
             @ApiResponse(code = 500, message = "서버 오류")
     })
-    public Page<ReviewDto> getReviews(@RequestParam("discussionId") Long discussionId
+    public Page<ReviewResponseDto> getReviews(@RequestParam("discussionId") Long discussionId
             , @ApiIgnore @PageableDefault(sort = "createdAt") Pageable pageable) {
         PageRequest pageRequest = new PageRequest(pageable.getPageNumber(), pageable.getSort());
         Page<Review> entityPage = reviewService.findAllByDiscussionIdFetch(discussionId, pageRequest.of());
-        return entityPage.map(ReviewDto::fromEntity);
+        return entityPage.map(ReviewResponseDto::fromEntity);
     }
 
     @PutMapping("livediff/{diffId}")

--- a/src/main/java/com/hidiscuss/backend/controller/dto/ReviewResponseDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/ReviewResponseDto.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
-public class ReviewDto extends BaseResponseDto {
+public class ReviewResponseDto extends BaseResponseDto {
     private Long id;
     private UserResponseDto reviewer;
     private List<CommentReviewDiffResponseDto> commentDiffList = new ArrayList<>();
@@ -20,8 +20,8 @@ public class ReviewDto extends BaseResponseDto {
     private Boolean accepted;
     private ReviewType reviewType;
 
-    public static ReviewDto fromEntity(Review review) {
-        ReviewDto dto = new ReviewDto();
+    public static ReviewResponseDto fromEntity(Review review) {
+        ReviewResponseDto dto = new ReviewResponseDto();
         dto.setBaseResponse(review);
         dto.id = review.getId();
         dto.reviewer = UserResponseDto.fromEntity(review.getReviewer());

--- a/src/main/java/com/hidiscuss/backend/entity/Discussion.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Discussion.java
@@ -64,4 +64,6 @@ public class Discussion extends BaseEntity {
     public void setTags(List<DiscussionTag> tags) { this.tags = tags; }
 
     public void complete() { this.state = DiscussionState.COMPLETED; }
+
+    public void reviewing() { this.state = DiscussionState.REVIEWING; }
 }

--- a/src/main/java/com/hidiscuss/backend/entity/DiscussionCode.java
+++ b/src/main/java/com/hidiscuss/backend/entity/DiscussionCode.java
@@ -3,6 +3,8 @@ package com.hidiscuss.backend.entity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
 
@@ -18,6 +20,7 @@ public class DiscussionCode extends BaseEntity {
 
     @ManyToOne
     @JoinColumn(name = "discussion_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Discussion discussion;
 
     @Column(name = "filename", nullable = false)

--- a/src/main/java/com/hidiscuss/backend/service/ReviewService.java
+++ b/src/main/java/com/hidiscuss/backend/service/ReviewService.java
@@ -31,7 +31,6 @@ public class ReviewService {
                 .findByIdFetchOrNull(dto.discussionId);
         if (discussion == null)
             throw new NoSuchElementException("Discussion not found");
-
         if (discussion.getUser().getId().equals(user.getId()))
             throw new UserAuthorityException("Cannot review your own code");
         Review review = Review.builder()
@@ -44,6 +43,9 @@ public class ReviewService {
         review = reviewRepository.save(review);
         List<CommentReviewDiff> diffList = commentReviewDiffService.createCommentReviewDiff(review, dto.getDiffList());
         review.setCommentDiffList(diffList);
+//        if (discussion.getState().equals(DiscussionState.NOT_REVIEWED)) {
+            discussion.reviewing();
+//        }
         return review;
     }
 


### PR DESCRIPTION
## 티켓
없음!

## 작업 내용
- [x] `CommentReview` 최초 생성시 Discussion 상태 `REVIEWING`으로 변경
- [x] `ReviewDto` -> `ReviewResponseDto`로 네이밍 변경
- [x] `Discussion` 완료 api uri 변경
- [x] `DiscussionCode`에 `OnDeleteAction.CASCADE` 설정
