### PR TITLE
FIX: 라이브 리뷰 예약 관련 수정

### DIFF
--- a/src/main/java/com/hidiscuss/backend/controller/ReviewReservationController.java
+++ b/src/main/java/com/hidiscuss/backend/controller/ReviewReservationController.java
@@ -90,7 +90,7 @@ public class ReviewReservationController {
             @ApiResponse(code = 400, message = "ReviewReservationID가 null 또는 reviewreservation이 존재하지 않음"),
             @ApiResponse(code = 500, message = "서버 에러")
     })
-    public ReviewReservationResponseDto enterLiveReviewReservation(@PathVariable("reservationId") Long reservationId, @AuthenticationPrincipal String userId) {
+    public ReviewReservationResponseDto enterLiveReviewReservation(@PathVariable("reservationId") Long reservationId, @AuthenticationPrincipal User user) {
         ReviewReservation reviewReservation = reviewReservationService.findByIdOrNull(reservationId);
         if (reviewReservation == null) {
             throw NotFoundReservaiton();

--- a/src/main/java/com/hidiscuss/backend/service/ReviewReservationService.java
+++ b/src/main/java/com/hidiscuss/backend/service/ReviewReservationService.java
@@ -29,6 +29,7 @@ public class ReviewReservationService {
     private final ReviewReservationRepository reviewReservationRepository;
     private final EmailService emailService;
     private final ReviewService reviewService;
+    private final UserService userService;
 
     public List<ReviewReservation> findByDiscussionId(Long discussionId) {
         return reviewReservationRepository.findByDiscussionId(discussionId);
@@ -62,12 +63,16 @@ public class ReviewReservationService {
         boolean isAvailableInsert = liveReviewAvailableTimes.getTimes().stream().anyMatch(timeRange -> {
           ZonedDateTime start = timeRange.getStart();
           ZonedDateTime end = timeRange.getEnd();
-          return start.isBefore(startTime) && end.isAfter(startTime);
+          return start.isBefore(startTime) && end.isAfter(startTime) || start.isEqual(startTime);
         });
 
         if(!isAvailableInsert) {
             throw new IllegalArgumentException("예약 가능한 시간이 아닙니다.");
         }
+
+        // TODO : reviewer 가 같은 시간에 예약 하는지 체크
+
+        reviewer = userService.findById(reviewer.getId()); // 이메일 전송에 사용하기 위해서 업데이트
 
         ReviewReservation reviewReservation = ReviewReservation.builder()
                 .reviewStartDateTime(startTime.minusSeconds(1))

--- a/src/main/java/com/hidiscuss/backend/service/ReviewReservationService.java
+++ b/src/main/java/com/hidiscuss/backend/service/ReviewReservationService.java
@@ -70,7 +70,7 @@ public class ReviewReservationService {
         }
 
         ReviewReservation reviewReservation = ReviewReservation.builder()
-                .reviewStartDateTime(startTime)
+                .reviewStartDateTime(startTime.minusSeconds(1))
                 .discussion(discussion)
                 .reviewer(reviewer)
                 .build();


### PR DESCRIPTION
## 티켓

[CAPS-?](link)

## 작업 내용
- [x] 컨트롤러 파라미터 타입 수정
- [x] 메일 보낼 시 `user.email` nullable 일 수 있음 : 다시 쿼리
- [x] 리뷰 시작 시간 겹침 수정