### PR TITLE
CAPS-205: StyleReview 생성 시 ReviewDiff 잘 나타나도록 수정

### DIFF
--- a/src/main/java/com/hidiscuss/backend/controller/OAuth2SuccessHandler.java
+++ b/src/main/java/com/hidiscuss/backend/controller/OAuth2SuccessHandler.java
@@ -42,7 +42,7 @@ public class OAuth2SuccessHandler extends SavedRequestAwareAuthenticationSuccess
         OAuth2User oAuth2User = (OAuth2User)authentication.getPrincipal();
         String gitaccessToken = oAuth2User.getAttribute("accessToken");
         // 최초 로그인이라면 회원가입 처리를 한다.
-        User newUser = userRepository.findByName(oAuth2User.getName());
+        User newUser = userRepository.findByName(oAuth2User.getName()).get();
         if (newUser == null) {
             GitHub gitHub = GitHub.connectUsingOAuth(gitaccessToken);
             List<GHEmail>  ghEmails2 = gitHub.getMyself().getEmails2();

--- a/src/main/java/com/hidiscuss/backend/controller/ReviewReservationController.java
+++ b/src/main/java/com/hidiscuss/backend/controller/ReviewReservationController.java
@@ -90,7 +90,7 @@ public class ReviewReservationController {
             @ApiResponse(code = 400, message = "ReviewReservationID가 null 또는 reviewreservation이 존재하지 않음"),
             @ApiResponse(code = 500, message = "서버 에러")
     })
-    public ReviewReservationResponseDto enterLiveReviewReservation(@PathVariable("reservationId") Long reservationId, @AuthenticationPrincipal String userId) {
+    public ReviewReservationResponseDto enterLiveReviewReservation(@PathVariable("reservationId") Long reservationId, @AuthenticationPrincipal User user) {
         ReviewReservation reviewReservation = reviewReservationService.findByIdOrNull(reservationId);
         if (reviewReservation == null) {
             throw NotFoundReservaiton();

--- a/src/main/java/com/hidiscuss/backend/controller/UserController.java
+++ b/src/main/java/com/hidiscuss/backend/controller/UserController.java
@@ -25,13 +25,4 @@ public class UserController {
         this.userService = userService;
     }
 
-    @ApiOperation(value="테스트 사용자 호출", notes="이 api는 테스트 api입니다. 여기에 api 동작 설명을 작성해주세요.")
-    @ApiResponses({
-            @ApiResponse(code = 200, message = "API 정상 작동"),
-            @ApiResponse(code = 500, message = "서버 에러")
-    })
-    @GetMapping("/userlist")
-    public ResponseEntity<List<User>> getUserList() {
-        return new ResponseEntity<>(userService.getUserList(), HttpStatus.OK);
-    }
 }

--- a/src/main/java/com/hidiscuss/backend/repository/UserRepository.java
+++ b/src/main/java/com/hidiscuss/backend/repository/UserRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
-    User findByName(String name);
     Optional<User> findById(Long userId);
+    Optional<User> findByName(String autobotName);
 }

--- a/src/main/java/com/hidiscuss/backend/service/DiscussionService.java
+++ b/src/main/java/com/hidiscuss/backend/service/DiscussionService.java
@@ -10,6 +10,7 @@ import com.hidiscuss.backend.exception.UserAuthorityException;
 import com.hidiscuss.backend.repository.DiscussionCodeRepository;
 import com.hidiscuss.backend.repository.DiscussionRepository;
 import com.hidiscuss.backend.repository.ReviewRepository;
+import com.hidiscuss.backend.utils.DbInitilization;
 import lombok.AllArgsConstructor;
 import org.kohsuke.github.GHCommit;
 import org.kohsuke.github.GHPullRequest;
@@ -18,6 +19,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import javax.annotation.PostConstruct;
 import javax.transaction.Transactional;
 import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
@@ -35,6 +37,7 @@ public class DiscussionService {
     private final DiscussionCodeRepository discussionCodeRepository;
     private final ReviewRepository reviewRepository;
     private final GithubService githubService;
+    private final UserService userService;
     private final DiscussionCodeService discussionCodeService;
     private final DiscussionTagService discussionTagService;
     private final ReviewReservationService reviewReservationService;
@@ -48,7 +51,6 @@ public class DiscussionService {
         Discussion discussion = CreateDiscussionRequestDto.toEntity(dto, user);
         discussion = discussionRepository.save(discussion);
         List<DiscussionCode> codes = new ArrayList<>();
-        User autoBot = User.builder().id(9999L).build();
 
         // Processing Tag
         discussion.setTags(discussionTagService.create(discussion, dto.tagIds));
@@ -73,7 +75,7 @@ public class DiscussionService {
         if (!pyCodes.isEmpty()) {
             List<CreateCommentReviewDiffDto> diffList = styleReviewService.createStyleReviewDto(pyCodes);
             CreateCommentReviewRequestDto styleReviewDto = new CreateCommentReviewRequestDto(discussion.getId(), diffList);
-            reviewService.createCommentReview(autoBot, styleReviewDto, ReviewType.COMMENT);
+            reviewService.createCommentReview(userService.getAutobot(), styleReviewDto, ReviewType.COMMENT);
         }
         return discussion;
     }

--- a/src/main/java/com/hidiscuss/backend/service/ReviewService.java
+++ b/src/main/java/com/hidiscuss/backend/service/ReviewService.java
@@ -66,7 +66,7 @@ public class ReviewService {
                 .build();
         reviewRepository.save(review);
 
-        List <DiscussionCode> discussionCodeList = discussionCodeService.findDiscussionCocde(reviewReservation.getDiscussion());
+        List <DiscussionCode> discussionCodeList = discussionCodeService.getDiscussionCode(reviewReservation.getDiscussion());
 
         List<LiveReviewDiff> liveReviewDiffList = new ArrayList<>();
 

--- a/src/main/java/com/hidiscuss/backend/service/ReviewService.java
+++ b/src/main/java/com/hidiscuss/backend/service/ReviewService.java
@@ -47,7 +47,7 @@ public class ReviewService {
         review = reviewRepository.save(review);
         List<CommentReviewDiff> diffList = commentReviewDiffService.createCommentReviewDiff(review, dto.getDiffList());
         review.setCommentDiffList(diffList);
-        if (!user.getId().equals(9999L)) {
+        if (!user.getName().equals(UserService.AUTOBOT_NAME)) {
             discussion.reviewing();
         }
         return review;

--- a/src/main/java/com/hidiscuss/backend/service/ReviewService.java
+++ b/src/main/java/com/hidiscuss/backend/service/ReviewService.java
@@ -46,9 +46,9 @@ public class ReviewService {
         review = reviewRepository.save(review);
         List<CommentReviewDiff> diffList = commentReviewDiffService.createCommentReviewDiff(review, dto.getDiffList());
         review.setCommentDiffList(diffList);
-//        if (discussion.getState().equals(DiscussionState.NOT_REVIEWED)) {
+        if (!user.getId().equals(9999L)) {
             discussion.reviewing();
-//        }
+        }
         return review;
     }
 

--- a/src/main/java/com/hidiscuss/backend/service/StyleReviewService.java
+++ b/src/main/java/com/hidiscuss/backend/service/StyleReviewService.java
@@ -38,8 +38,8 @@ public class StyleReviewService {
 
     private List<Long> getCodeLocate(String code, Map<String, String> diff) throws IOException {
         BufferedReader bf = new BufferedReader(new StringReader(code));
-        String tmpLine = "";
-        long offset = 0;
+        String tmpLine;
+        long offset;
         long line = Long.parseLong(diff.get("line"));
         long sum = 0L;
         try {

--- a/src/main/java/com/hidiscuss/backend/service/StyleReviewService.java
+++ b/src/main/java/com/hidiscuss/backend/service/StyleReviewService.java
@@ -36,7 +36,7 @@ public class StyleReviewService {
         return dtos;
     }
 
-    private List<Long> getCodeLocate(String code, Map<String, String> diff) {
+    private List<Long> getCodeLocate(String code, Map<String, String> diff) throws IOException {
         BufferedReader bf = new BufferedReader(new StringReader(code));
         String tmpLine = "";
         long offset = 0;
@@ -47,7 +47,7 @@ public class StyleReviewService {
                 sum += tmpLine.length() + 1;
             offset = tmpLine.length();
         } catch (Exception e) {
-            e.printStackTrace();
+            throw new IOException("this code cannot be read");
         }
 
         return List.of(sum, sum + offset);

--- a/src/main/java/com/hidiscuss/backend/service/StyleReviewService.java
+++ b/src/main/java/com/hidiscuss/backend/service/StyleReviewService.java
@@ -45,9 +45,9 @@ public class StyleReviewService {
         try {
             while (((tmpLine = bf.readLine()) != null) && (line-- > 1))
                 sum += tmpLine.length() + 1;
-            offset = tmpLine.length();
+            offset = (tmpLine == null) ? 0 : tmpLine.length();
         } catch (Exception e) {
-            throw new IllegalArgumentException("this code cannot be read");
+            throw new IllegalArgumentException("There was a problem creating style review");
         }
 
         return List.of(sum, sum + offset);

--- a/src/main/java/com/hidiscuss/backend/service/StyleReviewService.java
+++ b/src/main/java/com/hidiscuss/backend/service/StyleReviewService.java
@@ -37,16 +37,20 @@ public class StyleReviewService {
     }
 
     private List<Long> getCodeLocate(String code, Map<String, String> diff) {
+        BufferedReader bf = new BufferedReader(new StringReader(code));
+        String tmpLine = "";
+        long offset = 0;
         long line = Long.parseLong(diff.get("line"));
-        long column = Long.parseLong(diff.get("column"));
         long sum = 0L;
-        
-        String[] byLine = code.split("\n");
-        for (int i = 0; i < line - 1; i++) {
-            sum += byLine[i].length() + 1;
+        try {
+            while (((tmpLine = bf.readLine()) != null) && (line-- > 1))
+                sum += tmpLine.length() + 1;
+            offset = tmpLine.length();
+        } catch (Exception e) {
+            e.printStackTrace();
         }
-        sum += column;
-        return List.of(sum, sum + 1);
+
+        return List.of(sum, sum + offset);
     }
 
     private List<Map<String, String>> executeLint(String content) {

--- a/src/main/java/com/hidiscuss/backend/service/StyleReviewService.java
+++ b/src/main/java/com/hidiscuss/backend/service/StyleReviewService.java
@@ -36,7 +36,7 @@ public class StyleReviewService {
         return dtos;
     }
 
-    private List<Long> getCodeLocate(String code, Map<String, String> diff) throws IOException {
+    private List<Long> getCodeLocate(String code, Map<String, String> diff) {
         BufferedReader bf = new BufferedReader(new StringReader(code));
         String tmpLine;
         long offset;
@@ -47,7 +47,7 @@ public class StyleReviewService {
                 sum += tmpLine.length() + 1;
             offset = tmpLine.length();
         } catch (Exception e) {
-            throw new IOException("this code cannot be read");
+            throw new IllegalArgumentException("this code cannot be read");
         }
 
         return List.of(sum, sum + offset);

--- a/src/main/java/com/hidiscuss/backend/service/UserService.java
+++ b/src/main/java/com/hidiscuss/backend/service/UserService.java
@@ -2,26 +2,36 @@ package com.hidiscuss.backend.service;
 
 import com.hidiscuss.backend.entity.User;
 import com.hidiscuss.backend.repository.UserRepository;
+import com.hidiscuss.backend.utils.DbInitilization;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.NoSuchElementException;
+import javax.annotation.PostConstruct;
+import javax.transaction.Transactional;
 
 @Service
+@Slf4j
+@Transactional
+@AllArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
+    public static final String AUTOBOT_NAME = "AutoBot";
 
-    public UserService(UserRepository userRepository) {
-        this.userRepository = userRepository;
+    @PostConstruct
+    private void initAutobotService() {
+        User autobot = this.getAutobot();
+        if (autobot != null) {
+            return;
+        }
+        log.info("Initializing Autobot service");
+        autobot = DbInitilization.getInitialAutobot();
+        userRepository.save(autobot);
     }
 
-    public List<User> getUserList() {
-        return userRepository.getUserList();
-    }
-
-    public User findById(Long userId) {
-        return userRepository.findById(userId)
-                .orElseThrow(() -> new NoSuchElementException("No such user"));
+    public User getAutobot() {
+        return userRepository.findByName(AUTOBOT_NAME).orElse(null);
     }
 }

--- a/src/main/java/com/hidiscuss/backend/utils/DbInitilization.java
+++ b/src/main/java/com/hidiscuss/backend/utils/DbInitilization.java
@@ -1,6 +1,8 @@
 package com.hidiscuss.backend.utils;
 
 import com.hidiscuss.backend.entity.Tag;
+import com.hidiscuss.backend.entity.User;
+import com.hidiscuss.backend.service.UserService;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -36,5 +38,12 @@ public class DbInitilization {
                 "nosql"
         );
         return tagNames.stream().map(tag -> Tag.builder().name(tag).build()).collect(Collectors.toList());
+    }
+
+    public static User getInitialAutobot() {
+        return User.builder()
+                .name(UserService.AUTOBOT_NAME)
+                .email("hidiscuss-capstone@gmail.com")
+                .build();
     }
 }


### PR DESCRIPTION
## 티켓
[CAPS-205](https://2022springcapstone.atlassian.net/browse/CAPS-205)
[CAPS-206](https://2022springcapstone.atlassian.net/browse/CAPS-206)

## 작업 내용
- [x] `StyleReview`가 수행되었을 때, 수정이 필요한 코드 라인의 `codeAfter`가 빈 문자열로 변경되도록 처리
- [x] `StyleReview`가 생성되었을 때, discussion 상태가 NOT_REVIEWED로 유지되도록 처리

## 전달사항
- `codeAfter` 형식에 관해서 오늘(5/30) 회의 때 좀 더 설명드리겠습니다!
