### PR TITLE
feat: github repo link

### DIFF
--- a/src/main/java/com/hidiscuss/backend/controller/dto/DiscussionResponseDto.java
+++ b/src/main/java/com/hidiscuss/backend/controller/dto/DiscussionResponseDto.java
@@ -18,6 +18,7 @@ public class DiscussionResponseDto extends BaseResponseDto {
     private int state;
     private UserResponseDto user;
     private List<DiscussionTagDto> tags;
+    private String repoLink;
     public static DiscussionResponseDto fromEntity(Discussion entity) {
         DiscussionResponseDto dto = new DiscussionResponseDto();
         dto.setBaseResponse(entity);
@@ -30,6 +31,7 @@ public class DiscussionResponseDto extends BaseResponseDto {
         dto.state = entity.getState().getId();
         dto.tags = entity.getTags().stream().map(DiscussionTagDto::fromEntity).collect(Collectors.toList());
         dto.user = UserResponseDto.fromEntity(entity.getUser());
+        dto.repoLink = entity.getRepoLink();
         return dto;
     }
 }

--- a/src/main/java/com/hidiscuss/backend/entity/Discussion.java
+++ b/src/main/java/com/hidiscuss/backend/entity/Discussion.java
@@ -47,8 +47,11 @@ public class Discussion extends BaseEntity {
     @OneToMany(mappedBy = "discussion", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<DiscussionTag> tags = new ArrayList<>();
 
+    @Column(name = "repoLink", nullable = true)
+    private String repoLink;
+
     @Builder
-    public Discussion(Long id, User user, String question, String title, Boolean liveReviewRequired, LiveReviewAvailableTimes liveReviewAvailableTimes, Long priority) {
+    public Discussion(Long id, User user, String question, String title, Boolean liveReviewRequired, LiveReviewAvailableTimes liveReviewAvailableTimes, Long priority, String repoLink) {
         this.id = id;
         this.state = DiscussionState.NOT_REVIEWED;
         this.user = user;
@@ -57,6 +60,7 @@ public class Discussion extends BaseEntity {
         this.liveReviewRequired = liveReviewRequired;
         this.liveReviewAvailableTimes = liveReviewAvailableTimes;
         this.priority = priority;
+        this.repoLink = repoLink;
     }
 
     public void setUser(User user) {
@@ -64,6 +68,8 @@ public class Discussion extends BaseEntity {
     }
 
     public void setTags(List<DiscussionTag> tags) { this.tags = tags; }
+
+    public void setRepoLink(String repoLink) { this.repoLink = repoLink; }
 
     public void complete() { this.state = DiscussionState.COMPLETED; }
 

--- a/src/main/java/com/hidiscuss/backend/service/DiscussionService.java
+++ b/src/main/java/com/hidiscuss/backend/service/DiscussionService.java
@@ -45,6 +45,8 @@ public class DiscussionService {
             @NotNull User user
     ) {
         Discussion discussion = CreateDiscussionRequestDto.toEntity(dto, user);
+        if (!dto.gitRepositoryId.isBlank())
+            githubService.setRepositoryLink(discussion, Long.parseLong(dto.gitRepositoryId));
         discussion = discussionRepository.save(discussion);
         List<DiscussionCode> codes = new ArrayList<>();
 

--- a/src/main/java/com/hidiscuss/backend/service/GithubService.java
+++ b/src/main/java/com/hidiscuss/backend/service/GithubService.java
@@ -1,5 +1,6 @@
 package com.hidiscuss.backend.service;
 
+import com.hidiscuss.backend.entity.Discussion;
 import com.hidiscuss.backend.exception.GithubException;
 import com.hidiscuss.backend.utils.GithubContext;
 import org.kohsuke.github.*;
@@ -70,6 +71,14 @@ public class GithubService {
             return pr.listFiles().toList();
         } catch (IOException e) {
             throw new GithubException("Failed to get files", e);
+        }
+    }
+
+    public void setRepositoryLink(Discussion discussion, Long repoId) {
+        try {
+            discussion.setRepoLink(getGitHub().getRepositoryById(repoId).getHtmlUrl().toString());
+        } catch (IOException e) {
+            throw new GithubException("Failed to get repository link", e);
         }
     }
 }


### PR DESCRIPTION
## 티켓

[CAPS-316](https://2022springcapstone.atlassian.net/browse/CAPS-316)

## 작업 내용
- [x] `Discussion` 엔티티에 nullable repoLink 컬럼 추가
- [x] discussion 생성 시 `gitRepositoryId`가 들어오는 경우에 한해 repoLink에 값 추가
- [x] 필요한 경우 repoLink를 포함하는 응답 반환

## 전달사항
- 요구사항은 **discussion 상세 페이지 호출할 때 해당 repo 링크도 반환하도록 하는 것**이었는데, 상세 페이지 호출할 때는 github 관련 정보를 가지고 있는게 없어서 `Discussion` 엔티티 내부에 repository link를 저장해야겠다는 ... 판단을 내렸습니다.
- response dto 재사용으로 인해 몇몇 api에 repoLink가 추가되었습니다. 아래 참고해주세요!
  - discussion 생성 시 `DiscussionResponseDto`에 repoLink 필드 추가되었습니다.
  - discussion 상세 페이지 조회 시 `DiscussionDetailResponseDto`의 discussion 내에 repoLink 필드 추가되었습니다.
  - discussion 목록 조회 시 `DiscussionResponseDto`에 repoLink 필드 추가되었습니다.
